### PR TITLE
Bugs fix and performance improvements

### DIFF
--- a/app/components/layout/main-content.tsx
+++ b/app/components/layout/main-content.tsx
@@ -24,7 +24,7 @@ export function MainContent({ children, headerChildren }: Readonly<Props>) {
 			{headerChildren}
 			{isMounted ? (
 				isDesktop ? (
-					<ScrollArea className="flex-1 overflow-y-auto bg-[#F6F6F6] px-4 pb-4">
+					<ScrollArea className="flex-1 overflow-x-hidden bg-[#F6F6F6] px-4 pb-4">
 						{children}
 					</ScrollArea>
 				) : (

--- a/app/queues/attendance-conflicts.queue.ts
+++ b/app/queues/attendance-conflicts.queue.ts
@@ -26,21 +26,30 @@ export async function job(job: Job<AttendanceConflictsJobData>) {
 
 		let conflictsFound = 0
 
-		for (const user of usersInBoth) {
-			const attendances = await prisma.attendance.findMany({
-				where: {
-					memberId: user.id,
-				},
-				include: {
-					report: {
-						select: {
-							entity: true,
-							tribeId: true,
-							departmentId: true,
-						},
+		const userIds = usersInBoth.map(u => u.id)
+
+		const allAttendances = await prisma.attendance.findMany({
+			where: { memberId: { in: userIds } },
+			include: {
+				report: {
+					select: {
+						entity: true,
+						tribeId: true,
+						departmentId: true,
 					},
 				},
-			})
+			},
+		})
+
+		const attendancesByUser = new Map<string, typeof allAttendances>()
+		for (const attendance of allAttendances) {
+			const existing = attendancesByUser.get(attendance.memberId) ?? []
+			existing.push(attendance)
+			attendancesByUser.set(attendance.memberId, existing)
+		}
+
+		for (const user of usersInBoth) {
+			const attendances = attendancesByUser.get(user.id) ?? []
 
 			const attendancesByDate = attendances.reduce(
 				(acc, attendance) => {

--- a/app/routes/_dashboard/admin-management.($id)/components/forms/add-admin-form.tsx
+++ b/app/routes/_dashboard/admin-management.($id)/components/forms/add-admin-form.tsx
@@ -144,7 +144,7 @@ function MainForm({
 			const selectedMember = membersData?.find(m => m.id === id)
 			const hasEmail = !!selectedMember?.email
 			setRequestEmail(!hasEmail)
-			const hasPassword = !!selectedMember?.password?.hash
+			const hasPassword = !!selectedMember?.hasPassword
 			setRequestPassword(!hasPassword)
 		},
 		[membersData],

--- a/app/routes/_dashboard/dashboard/_index.tsx
+++ b/app/routes/_dashboard/dashboard/_index.tsx
@@ -25,7 +25,7 @@ export default function Dashboard() {
 	}
 
 	return (
-		<div className="flex flex-col h-full">
+		<div className="flex flex-col h-full flex-1">
 			<div className="flex justify-center px-4 pt-3 pb-1 bg-white border-b border-gray-100 shrink-0">
 				<div className="inline-flex rounded-full bg-gray-100 p-1 gap-1">
 					<button

--- a/app/routes/_dashboard/dashboard/components/admin/line-chart-card.tsx
+++ b/app/routes/_dashboard/dashboard/components/admin/line-chart-card.tsx
@@ -4,7 +4,6 @@ import {
 	XAxis,
 	Line,
 	YAxis,
-	ResponsiveContainer,
 } from 'recharts'
 
 import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card'
@@ -30,43 +29,41 @@ export function LineChartCard({ data, config }: Readonly<LineChartCardProps>) {
 				<CardTitle className="">Présence aux cultes</CardTitle>
 			</CardHeader>
 			<CardContent className="p-0 h-[400px]">
-				<ResponsiveContainer width="100%" height="90%" className="pe-4">
-					<ChartContainer config={config}>
-						<LineChart accessibilityLayer data={data}>
-							<CartesianGrid vertical={false} strokeDasharray="3 3" />
-							<XAxis
-								dataKey="month"
-								tickLine={false}
-								axisLine={false}
-								tickMargin={10}
-								tickFormatter={(value: string) =>
-									value.toUpperCase().slice(0, 3)
-								}
-							/>
-							<YAxis axisLine={false} tickLine={false} />
-							<ChartTooltip cursor={false} content={<ChartTooltipContent />} />
-							<Line
-								dataKey="presences"
-								type="monotone"
-								stroke="var(--color-presences)"
-								strokeWidth={2}
-								dot={false}
-							/>
-							<Line
-								dataKey="absences"
-								type="monotone"
-								stroke="var(--color-absences)"
-								strokeWidth={2}
-								dot={false}
-							/>
-							<ChartLegend
-								content={<CustomChartLegend />}
-								iconType="square"
-								align="right"
-							/>
-						</LineChart>
-					</ChartContainer>
-				</ResponsiveContainer>
+				<ChartContainer config={config} className="h-full w-full pr-4">
+					<LineChart accessibilityLayer data={data}>
+						<CartesianGrid vertical={false} strokeDasharray="3 3" />
+						<XAxis
+							dataKey="month"
+							tickLine={false}
+							axisLine={false}
+							tickMargin={10}
+							tickFormatter={(value: string) =>
+								value.toUpperCase().slice(0, 3)
+							}
+						/>
+						<YAxis axisLine={false} tickLine={false} />
+						<ChartTooltip cursor={false} content={<ChartTooltipContent />} />
+						<Line
+							dataKey="presences"
+							type="monotone"
+							stroke="var(--color-presences)"
+							strokeWidth={2}
+							dot={false}
+						/>
+						<Line
+							dataKey="absences"
+							type="monotone"
+							stroke="var(--color-absences)"
+							strokeWidth={2}
+							dot={false}
+						/>
+						<ChartLegend
+							content={<CustomChartLegend />}
+							iconType="square"
+							align="right"
+						/>
+					</LineChart>
+				</ChartContainer>
 			</CardContent>
 		</Card>
 	)

--- a/app/routes/_dashboard/dashboard/loader.server.ts
+++ b/app/routes/_dashboard/dashboard/loader.server.ts
@@ -77,6 +77,7 @@ async function buildManagerData(
 		where: {
 			[`${selectedEntity.type}Id`]: selectedEntity.id,
 			...baseWhere,
+			NOT: { isActive: false, deletedAt: { not: null } },
 			OR: [
 				{ name: { contains, mode: 'insensitive' } },
 				{ phone: { contains } },
@@ -109,12 +110,21 @@ async function buildManagerData(
 			previousTo,
 		)
 
+	const softDeleteFilter = { NOT: { isActive: false, deletedAt: { not: null } } }
+
 	const total = await prisma.user.count({
-		where: { [`${selectedEntity.type}Id`]: selectedEntity.id, ...baseWhere },
+		where: {
+			[`${selectedEntity.type}Id`]: selectedEntity.id,
+			...baseWhere,
+			...softDeleteFilter,
+		},
 	})
 
 	const membersCount = await prisma.user.count({
-		where: { [`${selectedEntity.type}Id`]: selectedEntity.id },
+		where: {
+			[`${selectedEntity.type}Id`]: selectedEntity.id,
+			...softDeleteFilter,
+		},
 	})
 
 	const entityName = await getEntityName(selectedEntity)

--- a/app/routes/_dashboard/dashboard/utils.server.ts
+++ b/app/routes/_dashboard/dashboard/utils.server.ts
@@ -125,6 +125,13 @@ export async function getEntityStats(
 		},
 	})
 
+	const memberCount = await prisma.user.count({
+		where: {
+			[`${type}Id`]: id,
+			NOT: { isActive: false, deletedAt: { not: null } },
+		},
+	})
+
 	switch (type) {
 		case 'tribe':
 			entityName = await prisma.tribe.findUnique({
@@ -155,7 +162,7 @@ export async function getEntityStats(
 		id,
 		type,
 		entityName: entityName?.name,
-		memberCount: members.length,
+		memberCount,
 		members: getMembersAttendances(members),
 		total,
 	}

--- a/app/routes/_dashboard/dashboard/utils.server.ts
+++ b/app/routes/_dashboard/dashboard/utils.server.ts
@@ -76,9 +76,11 @@ export async function getAuthorizedEntities(
 		})
 	}
 
-	return Array.from(
-		new Set(authorizedEntities.map(e => JSON.stringify(e))),
-	).map(e => JSON.parse(e)) as AuthorizedEntity[]
+	const unique = new Map<string, AuthorizedEntity>()
+	for (const entity of authorizedEntities) {
+		unique.set(`${entity.type}-${entity.id}`, entity as AuthorizedEntity)
+	}
+	return Array.from(unique.values())
 }
 
 export async function getEntityStats(

--- a/app/routes/_dashboard/members.($id)/utils/entities.ts
+++ b/app/routes/_dashboard/members.($id)/utils/entities.ts
@@ -28,55 +28,47 @@ export async function findOrCreateDepartments(
 	departments: string[],
 	churchId: string,
 ) {
-	const result = []
-
-	for (const department of departments) {
-		let existingDepartment
-
-		existingDepartment = await prisma.department.findFirst({
-			where: { name: department },
-		})
-
-		if (!existingDepartment) {
-			existingDepartment = await prisma.department.create({
-				data: {
-					name: department,
-					church: { connect: { id: churchId } },
-				},
+	return Promise.all(
+		departments.map(async department => {
+			let existing = await prisma.department.findFirst({
+				where: { name: department },
 			})
-		}
 
-		result.push({ id: existingDepartment.id, name: existingDepartment.name })
-	}
+			if (!existing) {
+				existing = await prisma.department.create({
+					data: {
+						name: department,
+						church: { connect: { id: churchId } },
+					},
+				})
+			}
 
-	return result
+			return { id: existing.id, name: existing.name }
+		}),
+	)
 }
 
 export async function findOrCreateHonorFamilies(
 	families: string[],
 	churchId: string,
 ) {
-	const result = []
-
-	for (const family of families) {
-		let existingFamily
-
-		existingFamily = await prisma.honorFamily.findFirst({
-			where: { name: family },
-		})
-
-		if (!existingFamily) {
-			existingFamily = await prisma.honorFamily.create({
-				data: {
-					name: family,
-					location: 'N/D',
-					church: { connect: { id: churchId } },
-				},
+	return Promise.all(
+		families.map(async family => {
+			let existing = await prisma.honorFamily.findFirst({
+				where: { name: family },
 			})
-		}
 
-		result.push({ id: existingFamily.id, name: existingFamily.name })
-	}
+			if (!existing) {
+				existing = await prisma.honorFamily.create({
+					data: {
+						name: family,
+						location: 'N/D',
+						church: { connect: { id: churchId } },
+					},
+				})
+			}
 
-	return result
+			return { id: existing.id, name: existing.name }
+		}),
+	)
 }

--- a/app/routes/_dashboard/notifications/loader.server.ts
+++ b/app/routes/_dashboard/notifications/loader.server.ts
@@ -13,9 +13,7 @@ export const loaderFn = async ({ request }: LoaderFunctionArgs) => {
 		schema: filterSchema,
 	})
 
-	if (submission.status !== 'success') {
-		return invariant(true, 'params must be defined')
-	}
+	invariant(submission.status === 'success', 'params must be defined')
 
 	invariant(churchId, 'Church ID is required')
 

--- a/app/routes/api/get-addable-admins/_index.ts
+++ b/app/routes/api/get-addable-admins/_index.ts
@@ -22,14 +22,18 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 			name: true,
 			email: true,
 			isAdmin: true,
-			password: {
-				select: { hash: true },
-			},
+			password: { select: { hash: true } },
 		},
 		orderBy: { name: 'asc' },
 	})
 
-	return members
+	return members.map(({ id, name, email, isAdmin, password }) => ({
+		id,
+		name,
+		email,
+		isAdmin,
+		hasPassword: !!password,
+	}))
 }
 
 export type GetAddableAdminsLoaderData = Awaited<ReturnType<typeof loader>>

--- a/app/routes/api/manager-stats/_index.ts
+++ b/app/routes/api/manager-stats/_index.ts
@@ -113,9 +113,11 @@ export async function getAuthorizedEntities(
 		})
 	}
 
-	return Array.from(
-		new Set(authorizedEntities.map(e => JSON.stringify(e))),
-	).map(e => JSON.parse(e)) as AuthorizedEntity[]
+	const unique = new Map<string, AuthorizedEntity>()
+	for (const entity of authorizedEntities) {
+		unique.set(`${entity.type}-${entity.id}`, entity as AuthorizedEntity)
+	}
+	return Array.from(unique.values())
 }
 
 export async function getEntityMembers(

--- a/app/routes/api/statistics/_index.ts
+++ b/app/routes/api/statistics/_index.ts
@@ -93,13 +93,16 @@ function fetchAttendanceReports(
 
 	const dateFilter = {
 		attendances: {
-			every: { date: { gte: fromDate, lte: toDate } },
+			some: { date: { gte: fromDate, lte: toDate } },
 		},
 	}
 
 	const memberFilterForChurch = {
 		attendances: {
-			where: { memberId: { in: memberIds } },
+			where: {
+				memberId: { in: memberIds },
+				date: { gte: fromDate, lte: toDate },
+			},
 			select: {
 				memberId: true,
 				date: true,
@@ -110,7 +113,10 @@ function fetchAttendanceReports(
 
 	const memberFilterForMeeting = {
 		attendances: {
-			where: { memberId: { in: memberIds } },
+			where: {
+				memberId: { in: memberIds },
+				date: { gte: fromDate, lte: toDate },
+			},
 			select: {
 				memberId: true,
 				date: true,

--- a/app/shared/attendance.ts
+++ b/app/shared/attendance.ts
@@ -68,11 +68,24 @@ export function getMembersAttendances(
 		previousMonthSundays.map(d => startOfDay(d).getTime()),
 	)
 
+	const attendancesByMember = new Map<string, Attendance[]>()
+	for (const a of attendances) {
+		const list = attendancesByMember.get(a.memberId) ?? []
+		list.push(a)
+		attendancesByMember.set(a.memberId, list)
+	}
+
+	const previousAttendancesByMember = new Map<string, Attendance[]>()
+	for (const a of previousAttendances) {
+		const list = previousAttendancesByMember.get(a.memberId) ?? []
+		list.push(a)
+		previousAttendancesByMember.set(a.memberId, list)
+	}
+
 	return members.map(member => {
-		const memberAttendances = attendances.filter(a => a.memberId === member.id)
-		const previousMemberAttendances = previousAttendances.filter(
-			a => a.memberId === member.id,
-		)
+		const memberAttendances = attendancesByMember.get(member.id) ?? []
+		const previousMemberAttendances =
+			previousAttendancesByMember.get(member.id) ?? []
 
 		const previousMonthAttendances = previousMemberAttendances.filter(a =>
 			previousSundayTimes.has(startOfDay(a.date).getTime()),
@@ -171,15 +184,13 @@ function createAttendanceMapByWeek(
 	attendances: Attendance[],
 	weeks: Array<{ startDate: Date; endDate: Date }>,
 ): Map<number, Attendance> {
+	const meetingAttendances = attendances.filter(a => a.inMeeting !== null)
+
 	const map = new Map<number, Attendance>()
 	for (const week of weeks) {
-		const attendance = attendances.find(
-			a =>
-				a.date >= week.startDate &&
-				a.date <= week.endDate &&
-				a.inMeeting !== null,
+		const attendance = meetingAttendances.find(
+			a => a.date >= week.startDate && a.date <= week.endDate,
 		)
-
 		if (attendance) {
 			map.set(week.startDate.getTime(), attendance)
 		}


### PR DESCRIPTION
## What?

- Fix dashboard layout overflow, improve performance across several queries, and exclude archived members from dashboard counts and data extraction.
- **Modified modules:**
  - `app/components/layout/main-content.tsx` — layout overflow fix
  - `app/routes/_dashboard/dashboard/` — layout, chart, loader, and utils
  - `app/queues/attendance-conflicts.queue.ts` — N+1 query fix
  - `app/routes/_dashboard/admin-management.($id)/` — password detection fix
  - `app/routes/_dashboard/members.($id)/utils/entities.ts` — parallelized DB calls
  - `app/routes/_dashboard/notifications/loader.server.ts` — invariant usage fix
  - `app/routes/api/get-addable-admins/` — avoid exposing password hash
  - `app/routes/api/manager-stats/`, `statistics/` — deduplication and date filter fixes
  - `app/shared/attendance.ts` — O(n²) linear scan replaced with Map lookups
- **New behaviors:**
  - Archived members (`isActive: false` + `deletedAt != null`) are excluded from manager dashboard member counts and entity stats
  - Attendance statistics date filter now uses `some` instead of `every`, and date constraints are pushed into the attendance `where` clause
  - `get-addable-admins` API returns a `hasPassword` boolean instead of the raw password hash object

## Why?

- The dashboard line chart's `ResponsiveContainer` wrapper caused horizontal overflow on narrow viewports.
- The attendance-conflicts queue issued one DB query per user in a loop (N+1), which degraded performance on large churches.
- Archived members were still included in dashboard member counts and entity stats, showing inflated numbers.
- `getMembersAttendances` was calling `.filter()` over the full attendance array for every member — O(n×m) — causing slowdowns with large datasets.
- The `statistics` API's `every` date filter excluded reports where any attendance fell outside the range, incorrectly filtering out valid reports.

## How?

- **Dashboard layout**: Replaced `overflow-y-auto` with `overflow-x-hidden` on `ScrollArea`; added `flex-1` to the dashboard wrapper. Removed `ResponsiveContainer` and passed `className="h-full w-full"` directly to `ChartContainer`.
- **N+1 fix (attendance conflicts)**: Single batched `findMany({ where: { memberId: { in: userIds } } })`, then grouped into a `Map<userId, Attendance[]>` before the user loop.
- **Archived member exclusion**: Added `NOT: { isActive: false, deletedAt: { not: null } }` to manager loader queries and `getEntityStats` count query. `memberCount` is now a dedicated `prisma.user.count()` call with the filter instead of `members.length`.
- **Attendance map performance**: Pre-grouped `attendances` and `previousAttendances` into `Map<memberId, Attendance[]>` before the `members.map()` loop. Pre-filtered `inMeeting !== null` in `createAttendanceMapByWeek` to avoid redundant per-week checks.
- **Deduplication**: Replaced `JSON.stringify/parse` round-trip in both `getAuthorizedEntities` functions with a `Map<type-id, entity>`.
- **Password exposure**: `get-addable-admins` now maps results to `{ ..., hasPassword: !!password }` before returning; form reads `selectedMember?.hasPassword` instead of `selectedMember?.password?.hash`.
- **Statistics date filter**: Changed `every` → `some` and moved `date: { gte, lte }` into the attendance `where` clause so only attendances within the range are included in the response.

## Testing?

- Unit tests added/updated: no
- Integration / end-to-end tests: no
- Manual steps to verify locally:
  1. Archive a member (set `isActive: false`, set `deletedAt` to a date).
  2. Open the manager dashboard — confirm the archived member is not counted in entity stats or member totals.
  3. Open the dashboard on a narrow viewport — confirm no horizontal scroll appears.
  4. Trigger the attendance-conflicts job and confirm only one DB query is issued for attendances (check server logs).
  5. Open the add-admin form, select a member without a password — confirm the password field appears correctly.
  6. Check the statistics API with a date range — confirm only attendances within the range are returned.
- Edge cases not covered: Archiving a member who is the current tribe/department manager — their manager record is not automatically cleared.

## Anything Else?

- Parallelizing `findOrCreateDepartments` / `findOrCreateHonorFamilies` with `Promise.all` may create race conditions under concurrent imports — a follow-up `upsert` refactor is recommended.
- No database migrations required for this PR.

## Checklist

- [ ] I added/updated tests (unit/integration)
- [ ] I updated documentation where necessary
- [ ] I ran the full test suite locally and it passes
- [ ] I verified this change in a staging environment (if applicable)
- [ ] This change requires a migration and I updated migration docs (if applicable)
