### PR TITLE
Bugfix

### DIFF
--- a/app/components/form/month-picker.tsx
+++ b/app/components/form/month-picker.tsx
@@ -113,7 +113,7 @@ const MonthPicker = ({
 						variant="outline"
 						type="button"
 						className={cn(
-							`min-w-[180px] flex items-center justify-between border-input font-normal capitalize ${label ? 'mt-3' : ''}`,
+							`min-w-[180px] flex items-center justify-between border-input font-normal ${label ? 'mt-3' : ''}`,
 							className,
 						)}
 					>

--- a/app/routes/_dashboard/archives-request/_index.tsx
+++ b/app/routes/_dashboard/archives-request/_index.tsx
@@ -14,12 +14,18 @@ import { loaderFn } from './loader.server'
 import { actionFn } from './action.server'
 import { useArchivesRequest } from './hooks/use-archives-request'
 import { GeneralErrorBoundary } from '~/components/error-boundary'
+import {
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
+} from '~/components/ui/dialog'
 
 export const loader = loaderFn
 export const action = actionFn
 
 export const meta: MetaFunction = () => [
-	{ title: "Jeriel | Demande d'archives" },
+	{ title: "Jeriel | Demande d'archivages" },
 ]
 
 const SPEED_DIAL_ITEMS: SpeedDialAction[] = [
@@ -34,17 +40,23 @@ export default function ArchiveRequest() {
 	const {
 		data,
 		isFormOpen,
+		editRequest,
+		requestToDelete,
 		setIsFormOpen,
 		handleClose,
 		handleDisplayMore,
 		handleSearch,
 		handleSpeedDialItemClick,
+		handleEdit,
+		handleDeleteRequest,
+		handleConfirmDelete,
+		handleCancelDelete,
 	} = useArchivesRequest()
 
 	return (
 		<MainContent
 			headerChildren={
-				<Header title="Demande d'archives">
+				<Header title="Demande d'archivage">
 					<Button
 						className="hidden sm:block"
 						variant="primary"
@@ -63,7 +75,11 @@ export default function ArchiveRequest() {
 				/>
 
 				<Card className="space-y-2 pb-4 mb-2">
-					<ArchiveRequestTable data={data.archiveRequests} />
+					<ArchiveRequestTable
+						data={data.archiveRequests}
+						onEdit={handleEdit}
+						onDelete={handleDeleteRequest}
+					/>
 
 					<div className="flex justify-center">
 						<Button
@@ -84,7 +100,44 @@ export default function ArchiveRequest() {
 				<ArchiveFormDialog
 					onClose={handleClose}
 					authorizedEntities={data.authorizedEntities}
+					editRequest={editRequest}
 				/>
+			)}
+
+			{requestToDelete && (
+				<Dialog open onOpenChange={handleCancelDelete}>
+					<DialogContent
+						className="md:max-w-md"
+						onOpenAutoFocus={e => e.preventDefault()}
+						onPointerDownOutside={e => e.preventDefault()}
+					>
+						<DialogHeader>
+							<DialogTitle className="text-red-500">
+								Supprimer la demande
+							</DialogTitle>
+						</DialogHeader>
+						<div className="mt-2 text-sm text-gray-700">
+							Voulez-vous vraiment supprimer cette demande d&apos;archivage ?
+							Cette action est irréversible.
+						</div>
+						<div className="flex justify-end gap-3 mt-4">
+							<Button
+								type="button"
+								variant="outline"
+								onClick={handleCancelDelete}
+							>
+								Annuler
+							</Button>
+							<Button
+								type="button"
+								variant="destructive"
+								onClick={handleConfirmDelete}
+							>
+								Supprimer
+							</Button>
+						</div>
+					</DialogContent>
+				</Dialog>
 			)}
 
 			<SpeedDialMenu

--- a/app/routes/_dashboard/archives-request/action.server.ts
+++ b/app/routes/_dashboard/archives-request/action.server.ts
@@ -1,17 +1,14 @@
 import type { ActionFunctionArgs } from '@remix-run/node'
 import invariant from 'tiny-invariant'
 import { requireUser } from '~/utils/auth.server'
-import { archiveUserSchema } from './schema'
+import {
+	archiveUserSchema,
+	deleteArchiveRequestSchema,
+	updateArchiveRequestSchema,
+} from './schema'
 import { parseWithZod } from '@conform-to/zod'
 import { prisma } from '~/infrastructures/database/prisma.server'
 import { notifyAdminAboutArchiveRequest } from '~/helpers/notification.server'
-
-export function getSubmissionData(formData: FormData) {
-	return parseWithZod(formData, {
-		schema: archiveUserSchema,
-		async: true,
-	})
-}
 
 export const actionFn = async ({ request }: ActionFunctionArgs) => {
 	const currentUser = await requireUser(request)
@@ -19,19 +16,18 @@ export const actionFn = async ({ request }: ActionFunctionArgs) => {
 	const formData = await request.formData()
 	const intent = formData.get('intent')
 
-	const submission = await getSubmissionData(formData)
-
-	if (submission.status !== 'success') return submission.reply()
-
 	invariant(currentUser.churchId, 'User must have a church')
-	invariant(
-		intent === 'archivate' || intent === 'request',
-		'Intent must be either "request" or "archivate"',
-	)
-
-	const { usersToArchive, origin } = submission.value
 
 	if (intent === 'request') {
+		const submission = await parseWithZod(formData, {
+			schema: archiveUserSchema,
+			async: true,
+		})
+
+		if (submission.status !== 'success') return submission.reply()
+
+		const { usersToArchive, origin } = submission.value
+
 		const archiveRequest = await prisma.archiveRequest.create({
 			data: {
 				origin,
@@ -44,9 +40,49 @@ export const actionFn = async ({ request }: ActionFunctionArgs) => {
 		})
 
 		await notifyAdminAboutArchiveRequest(archiveRequest.id, currentUser.id)
+
+		return { status: 'success' }
 	}
 
-	return { status: 'success' }
+	if (intent === 'update') {
+		const submission = await parseWithZod(formData, {
+			schema: updateArchiveRequestSchema,
+			async: true,
+		})
+
+		if (submission.status !== 'success') return submission.reply()
+
+		const { requestId, usersToArchive } = submission.value
+
+		await prisma.archiveRequest.update({
+			where: { id: requestId, requesterId: currentUser.id },
+			data: {
+				usersToArchive: {
+					set: usersToArchive.map((userId: string) => ({ id: userId })),
+				},
+			},
+		})
+
+		return { status: 'success' }
+	}
+
+	if (intent === 'delete') {
+		const submission = parseWithZod(formData, {
+			schema: deleteArchiveRequestSchema,
+		})
+
+		if (submission.status !== 'success') return submission.reply()
+
+		const { requestId } = submission.value
+
+		await prisma.archiveRequest.delete({
+			where: { id: requestId, requesterId: currentUser.id },
+		})
+
+		return { status: 'success' }
+	}
+
+	throw new Response('Invalid intent', { status: 400 })
 }
 
 export type ActionType = typeof actionFn

--- a/app/routes/_dashboard/archives-request/components/archive-form-dialog.tsx
+++ b/app/routes/_dashboard/archives-request/components/archive-form-dialog.tsx
@@ -16,10 +16,11 @@ import {
 import { Button } from '~/components/ui/button'
 import { useFetcher } from '@remix-run/react'
 import type { ActionType } from '../action.server'
-import type { ArchiveRequest } from '../model'
+import type { ArchiveRequest, User } from '../model'
 import { MOBILE_WIDTH } from '~/shared/constants'
 import MainForm from './main-form'
 import { useCallback, useEffect, useState } from 'react'
+import type { RowSelectionState } from '@tanstack/react-table'
 import type { AuthorizedEntity } from '../../dashboard/types'
 import { buildSearchParams } from '../../../../utils/url'
 import { useApiData } from '../../../../hooks/api-data.hook'
@@ -29,19 +30,33 @@ import { toast } from 'sonner'
 interface Props {
 	onClose: () => void
 	authorizedEntities: AuthorizedEntity[]
+	editRequest?: ArchiveRequest
 }
 
-export function ArchiveFormDialog({ onClose, authorizedEntities }: Props) {
+export function ArchiveFormDialog({
+	onClose,
+	authorizedEntities,
+	editRequest,
+}: Props) {
 	const isDesktop = useMediaQuery(MOBILE_WIDTH)
 	const fetcher = useFetcher<ActionType>()
 	const [archiveRequest, setArchiveRequest] = useState<ArchiveRequest>({
 		usersToArchive: [],
 	})
+	const [initialRowSelection, setInitialRowSelection] =
+		useState<RowSelectionState>({})
 
 	const isSubmitting = ['loading', 'submitting'].includes(fetcher.state)
-	const title = `Demande d'archive`
 
-	const defaultEntity = authorizedEntities[0]
+	const title = editRequest
+		? "Modifier la demande d'archivage"
+		: "Demande d'archivage"
+
+	const defaultEntity = editRequest
+		? (authorizedEntities.find(e => e.name === editRequest.origin) ??
+			authorizedEntities[0])
+		: authorizedEntities[0]
+
 	const defaultParams = getEntityParams(defaultEntity)
 
 	const apiData = useApiData<GetAllMembersApiData>(
@@ -76,12 +91,22 @@ export function ArchiveFormDialog({ onClose, authorizedEntities }: Props) {
 
 	useEffect(() => {
 		if (apiData.data) {
+			const members = apiData.data as unknown as User[]
 			setArchiveRequest(prev => ({
 				...prev,
-				usersToArchive: apiData.data as unknown as any[],
+				usersToArchive: members,
 			}))
+
+			if (editRequest) {
+				const editIds = new Set(editRequest.usersToArchive.map(u => u.id))
+				const selection = members.reduce((acc, user, index) => {
+					if (editIds.has(user.id)) acc[index] = true
+					return acc
+				}, {} as RowSelectionState)
+				setInitialRowSelection(selection)
+			}
 		}
-	}, [apiData.data])
+	}, [apiData.data, editRequest])
 
 	useEffect(() => {
 		getSelectedEntityMembers(defaultEntity)
@@ -105,8 +130,11 @@ export function ArchiveFormDialog({ onClose, authorizedEntities }: Props) {
 						fetcher={fetcher}
 						onClose={onClose}
 						authorizedEntities={authorizedEntities}
-						onFilter={getSelectedEntityMembers}
+						onFilter={editRequest ? () => {} : getSelectedEntityMembers}
 						defaultEntity={defaultEntity}
+						requestId={editRequest?.id}
+						initialRowSelection={initialRowSelection}
+						disableEntitySelect={!!editRequest}
 					/>
 				</DialogContent>
 			</Dialog>
@@ -125,8 +153,11 @@ export function ArchiveFormDialog({ onClose, authorizedEntities }: Props) {
 					fetcher={fetcher}
 					className="px-4"
 					authorizedEntities={authorizedEntities}
-					onFilter={getSelectedEntityMembers}
+					onFilter={editRequest ? () => {} : getSelectedEntityMembers}
 					defaultEntity={defaultEntity}
+					requestId={editRequest?.id}
+					initialRowSelection={initialRowSelection}
+					disableEntitySelect={!!editRequest}
 				/>
 				<DrawerFooter className="pt-2">
 					<DrawerClose asChild>

--- a/app/routes/_dashboard/archives-request/components/archive-request-table.tsx
+++ b/app/routes/_dashboard/archives-request/components/archive-request-table.tsx
@@ -14,12 +14,20 @@ import {
 } from '~/components/ui/table'
 import { archiveRequestColumns } from './columns'
 import type { ArchiveRequest } from '../model'
+import { RiDeleteBinLine, RiEditLine } from '@remixicon/react'
+import { Button } from '~/components/ui/button'
 
 interface Props {
 	data: ArchiveRequest[]
+	onEdit: (archiveRequest: ArchiveRequest) => void
+	onDelete: (archiveRequest: ArchiveRequest) => void
 }
 
-export function ArchiveRequestTable({ data }: Props) {
+export function ArchiveRequestTable({
+	data,
+	onEdit,
+	onDelete,
+}: Readonly<Props>) {
 	const table = useReactTable({
 		data,
 		columns: archiveRequestColumns,
@@ -55,7 +63,37 @@ export function ArchiveRequestTable({ data }: Props) {
 							data-state={row.getIsSelected() && 'selected'}
 						>
 							{row.getVisibleCells().map(cell => {
-								return (
+								const request = cell.row.original
+								const isPending = request.usersToArchive.some(
+									user => !user.deletedAt,
+								)
+
+								return cell.column.id === 'actions' ? (
+									<TableCell
+										key={cell.id}
+										className="flex items-center gap-2 text-xs sm:text-sm"
+									>
+										{isPending && (
+											<>
+												<Button
+													variant="primary-ghost"
+													size="icon-sm"
+													onClick={() => onEdit(request)}
+												>
+													<RiEditLine size={20} />
+												</Button>
+												<Button
+													variant="ghost"
+													size="icon-sm"
+													className="text-red-500 hover:text-red-600 hover:bg-red-50"
+													onClick={() => onDelete(request)}
+												>
+													<RiDeleteBinLine size={20} />
+												</Button>
+											</>
+										)}
+									</TableCell>
+								) : (
 									<TableCell
 										key={cell.id}
 										className="min-w-40 sm:min-w-0 text-xs sm:text-sm"

--- a/app/routes/_dashboard/archives-request/components/columns.tsx
+++ b/app/routes/_dashboard/archives-request/components/columns.tsx
@@ -52,4 +52,8 @@ export const archiveRequestColumns: ColumnDef<ArchiveRequest>[] = [
 			return <span>{createdAt ? format(createdAt, 'dd/MM/yyyy') : '-'}</span>
 		},
 	},
+	{
+		id: 'actions',
+		header: 'Actions',
+	},
 ]

--- a/app/routes/_dashboard/archives-request/components/main-form.tsx
+++ b/app/routes/_dashboard/archives-request/components/main-form.tsx
@@ -22,6 +22,9 @@ interface MainFormProps extends React.ComponentProps<'form'> {
 	authorizedEntities: AuthorizedEntity[]
 	defaultEntity: AuthorizedEntity
 	onFilter: (entity?: AuthorizedEntity) => void
+	requestId?: string
+	initialRowSelection?: RowSelectionState
+	disableEntitySelect?: boolean
 }
 
 export default function MainForm({
@@ -33,11 +36,16 @@ export default function MainForm({
 	authorizedEntities,
 	onFilter,
 	defaultEntity,
+	requestId,
+	initialRowSelection,
+	disableEntitySelect,
 }: MainFormProps) {
 	const formAction = '.'
 	const schema = archiveUserSchema
 
-	const [rowSelection, setRowSelection] = useState<RowSelectionState>({})
+	const [rowSelection, setRowSelection] = useState<RowSelectionState>(
+		initialRowSelection ?? {},
+	)
 	const [selectedEntity, setSelectedEntity] = useState<
 		AuthorizedEntity | undefined
 	>(defaultEntity)
@@ -54,13 +62,24 @@ export default function MainForm({
 		const entity = authorizedEntities.find(a => a.id === value)
 		onFilter(entity)
 		setSelectedEntity(entity)
+		setRowSelection({})
 	}
+
+	useEffect(() => {
+		if (
+			initialRowSelection &&
+			Object.keys(initialRowSelection).length > 0
+		) {
+			setRowSelection(initialRowSelection)
+		}
+	}, [initialRowSelection])
 
 	useEffect(() => {
 		const getSelectedRows = () => {
 			return Object.keys(rowSelection)
 				.filter(index => rowSelection[index])
 				.map(index => archiveRequest.usersToArchive[parseInt(index, 10)])
+				.filter(Boolean)
 				.map(user => user.id)
 		}
 
@@ -83,14 +102,19 @@ export default function MainForm({
 			className={cn('grid items-start gap-4 pt-4', className)}
 			encType="multipart/form-data"
 		>
+			{requestId && (
+				<input type="hidden" name="requestId" value={requestId} />
+			)}
+
 			<SelectInput
-				items={authorizedEntities.map(({ name, id, type }) => ({
+				items={authorizedEntities.map(({ name, id }) => ({
 					label: name ?? '',
 					value: id,
 				}))}
 				defaultValue={selectedEntity?.id}
 				onChange={onFilterChange}
 				placeholder=""
+				disabled={disableEntitySelect}
 			/>
 
 			<Card className="space-y-2 pb-4 mt-5 mb-2 max-h-[calc(50vh-10px)] overflow-y-auto">
@@ -115,12 +139,12 @@ export default function MainForm({
 				<Button
 					type="submit"
 					name="intent"
-					value={'request'}
+					value={requestId ? 'update' : 'request'}
 					variant={'primary'}
 					disabled={isLoading}
 					className="w-full sm:w-auto"
 				>
-					Soumettre
+					{requestId ? 'Modifier' : 'Soumettre'}
 				</Button>
 			</div>
 		</fetcher.Form>

--- a/app/routes/_dashboard/archives-request/hooks/use-archives-request.ts
+++ b/app/routes/_dashboard/archives-request/hooks/use-archives-request.ts
@@ -9,14 +9,21 @@ import { useDebounceCallback } from 'usehooks-ts'
 import { buildSearchParams } from '~/utils/url'
 import type { FilterOption } from '../schema'
 import { type LoaderType } from '../loader.server'
+import type { ArchiveRequest } from '../model'
+import { toast } from 'sonner'
 
 export const useArchivesRequest = () => {
 	const initialData = useLoaderData<LoaderType>()
 	const [data, setData] = useState(initialData)
 	const [isFormOpen, setIsFormOpen] = useState<boolean>(false)
+	const [editRequest, setEditRequest] = useState<ArchiveRequest | undefined>()
+	const [requestToDelete, setRequestToDelete] = useState<
+		ArchiveRequest | undefined
+	>()
 
 	const location = useLocation()
-	const { load, ...fetcher } = useFetcher<LoaderType>()
+	const { load, submit, ...fetcher } = useFetcher<LoaderType>()
+	const deleteFetcher = useFetcher<{ status: string }>()
 	const [searchParams, setSearchParams] = useSearchParams()
 	const debouncedSetSearchParams = useDebounceCallback(setSearchParams, 500)
 
@@ -40,8 +47,21 @@ export const useArchivesRequest = () => {
 		}
 	}, [searchParams, location.pathname, load])
 
+	useEffect(() => {
+		if (
+			deleteFetcher.state === 'idle' &&
+			deleteFetcher.data?.status === 'success'
+		) {
+			toast.success('Demande supprimée avec succès.')
+			setRequestToDelete(undefined)
+			reloadData({ ...data.filterOption, page: 1 })
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [deleteFetcher.state, deleteFetcher.data])
+
 	const handleClose = useCallback(() => {
 		setIsFormOpen(false)
+		setEditRequest(undefined)
 		reloadData({ ...data.filterOption, page: 1 })
 	}, [data.filterOption, reloadData])
 
@@ -68,13 +88,41 @@ export const useArchivesRequest = () => {
 		}
 	}
 
+	const handleEdit = useCallback((request: ArchiveRequest) => {
+		setEditRequest(request)
+		setIsFormOpen(true)
+	}, [])
+
+	const handleDeleteRequest = useCallback((request: ArchiveRequest) => {
+		setRequestToDelete(request)
+	}, [])
+
+	const handleConfirmDelete = useCallback(() => {
+		if (!requestToDelete?.id) return
+
+		deleteFetcher.submit(
+			{ intent: 'delete', requestId: requestToDelete.id },
+			{ method: 'post', action: '.' },
+		)
+	}, [deleteFetcher, requestToDelete])
+
+	const handleCancelDelete = useCallback(() => {
+		setRequestToDelete(undefined)
+	}, [])
+
 	return {
 		data,
 		isFormOpen,
+		editRequest,
+		requestToDelete,
 		setIsFormOpen,
 		handleClose,
 		handleDisplayMore,
 		handleSearch,
 		handleSpeedDialItemClick,
+		handleEdit,
+		handleDeleteRequest,
+		handleConfirmDelete,
+		handleCancelDelete,
 	}
 }

--- a/app/routes/_dashboard/archives-request/schema.ts
+++ b/app/routes/_dashboard/archives-request/schema.ts
@@ -7,6 +7,17 @@ export const archiveUserSchema = z.object({
 		.transform(v => v.split(';')),
 })
 
+export const deleteArchiveRequestSchema = z.object({
+	requestId: z.string({ required_error: 'ID de la demande requis' }),
+})
+
+export const updateArchiveRequestSchema = z.object({
+	requestId: z.string({ required_error: 'ID de la demande requis' }),
+	usersToArchive: z
+		.string({ required_error: 'Veuillez faire au moins une sélection' })
+		.transform(v => v.split(';')),
+})
+
 export const querySchema = z.object({
 	take: z.number().default(10),
 	page: z.number().default(1),

--- a/app/routes/_dashboard/archives.($id)/_index.tsx
+++ b/app/routes/_dashboard/archives.($id)/_index.tsx
@@ -1,5 +1,4 @@
 import { type MetaFunction } from '@remix-run/react'
-import { RiAddLine } from '@remixicon/react'
 import { Header } from '~/components/layout/header'
 import { MainContent } from '~/components/layout/main-content'
 import { Button } from '~/components/ui/button'
@@ -8,7 +7,6 @@ import { TableToolbar } from '~/components/toolbar'
 import { ArchiveFormDialog } from './components/archive-form-dialog'
 import { ArchiveRequestTable } from './components/archive-request-table'
 import { ArchivedUsersTable } from './components/archived-users-table'
-import SpeedDialMenu from '~/components/layout/mobile/speed-dial-menu'
 import { loaderFn } from './loader.server'
 import { actionFn } from './action.server'
 import { ConfirmDialog } from '../../../shared/forms/confirm-form-dialog'
@@ -17,14 +15,6 @@ import { GeneralErrorBoundary } from '~/components/error-boundary'
 
 export const loader = loaderFn
 export const action = actionFn
-
-const SPEED_DIAL_ITEMS = [
-	{
-		Icon: RiAddLine,
-		label: 'Ajouter un département',
-		action: 'add-department',
-	},
-]
 
 const VIEWS = [
 	{ id: 'ARCHIVE_REQUEST' as const, label: 'Demandes' },
@@ -48,7 +38,6 @@ export default function Archives() {
 		handleLoadMore,
 		handleOnClose,
 		handleOnUnarchive,
-		handleOpenRequestArchive,
 		handleSearch,
 	} = useArchives()
 
@@ -129,13 +118,6 @@ export default function Archives() {
 					successMessage="Utilisateur désarchivé avec succès."
 				/>
 			)}
-
-			<SpeedDialMenu
-				items={SPEED_DIAL_ITEMS}
-				onClick={action => {
-					if (action === 'request-an-archive') handleOpenRequestArchive()
-				}}
-			/>
 		</MainContent>
 	)
 }

--- a/app/routes/_dashboard/archives.($id)/hooks/use-archives.ts
+++ b/app/routes/_dashboard/archives.($id)/hooks/use-archives.ts
@@ -59,14 +59,6 @@ export const useArchives = () => {
 		load(`${location.pathname}?${params}`)
 	}, [data.filterOption, load, location.pathname])
 
-	const handleOpenRequestArchive = useCallback(() => {
-		if (!usersData) return
-		setFormState({
-			isOpen: true,
-			request: { usersToArchive: usersData as unknown as any[] },
-		})
-	}, [usersData])
-
 	const handleSearch = useCallback(
 		(query: string) => {
 			const params = buildSearchParams({
@@ -115,7 +107,6 @@ export const useArchives = () => {
 		handleLoadMore,
 		handleEdit,
 		handleOnUnarchive,
-		handleOpenRequestArchive,
 		handleSearch,
 	}
 }

--- a/app/routes/_dashboard/birthdays/_index.tsx
+++ b/app/routes/_dashboard/birthdays/_index.tsx
@@ -12,6 +12,7 @@ import {
 } from '@remix-run/react'
 import { Card } from '~/components/ui/card'
 import { Button } from '~/components/ui/button'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs'
 import { useCallback, useEffect, useState } from 'react'
 import { type DateRange } from 'react-day-picker'
 import { parseISO } from 'date-fns'
@@ -33,6 +34,10 @@ export default function Birthday() {
 	const [searchParams, setSearchParams] = useSearchParams()
 	const [data, setData] = useState(loaderData)
 
+	const activeTab = (searchParams.get('tab') ?? 'general') as
+		| 'general'
+		| 'week'
+
 	const [from, setFrom] = useState<Date | undefined>(
 		parseISO(data.filterData.from),
 	)
@@ -43,7 +48,7 @@ export default function Birthday() {
 	>(undefined)
 
 	const reloadData = useCallback(
-		(option: { from?: Date; to?: Date }) => {
+		(option: Record<string, unknown>) => {
 			const params = buildSearchParams(option)
 			setSearchParams(params)
 		},
@@ -60,19 +65,18 @@ export default function Birthday() {
 	)
 
 	const handleFilter = useCallback(() => {
-		const filter = {
+		reloadData({
+			tab: 'general',
 			from: from ? parseISO(from.toISOString()) : undefined,
 			to: to ? parseISO(to.toISOString()) : undefined,
-		}
-
-		reloadData(filter)
+		})
 	}, [from, reloadData, to])
 
 	const handleResetDateRange = useCallback(() => {
 		handleOnPeriodChange({ from: undefined, to: undefined })
 		setFrom(undefined)
 		setTo(undefined)
-		reloadData({ from: undefined, to: undefined })
+		reloadData({ tab: 'general' })
 	}, [handleOnPeriodChange, reloadData])
 
 	function handleDisplayMore() {
@@ -89,6 +93,12 @@ export default function Birthday() {
 		setOpenDetails(true)
 	}
 
+	function handleTabChange(tab: string) {
+		setFrom(undefined)
+		setTo(undefined)
+		reloadData({ tab })
+	}
+
 	useEffect(() => {
 		setData(loaderData)
 	}, [loaderData])
@@ -99,21 +109,67 @@ export default function Birthday() {
 
 	const entityType = data.userPermissions.managedEntities.map(d => d.type)
 
+	const birthdayCard = (
+		<Card className="space-y-2 pb-4 mb-2">
+			<BirthdayTable
+				data={data.birthdays}
+				entityType={entityType[0]}
+				canSeeAll={data.userPermissions.canSeeAll}
+				onSeeMember={handleBirthdayDetails}
+			/>
+			<div className="flex justify-center pb-2">
+				<Button
+					size="sm"
+					type="button"
+					variant="ghost"
+					disabled={data.filterData.take >= data.totalCount}
+					className="bg-neutral-200 rounded-full"
+					onClick={handleDisplayMore}
+				>
+					Voir plus
+				</Button>
+			</div>
+		</Card>
+	)
+
 	return (
 		<MainContent
 			headerChildren={
 				<Header title="Anniversaires">
-					<div className="flex space-x-2">
-						<div className="hidden sm:block">
-							<DateRangePicker
-								defaultLabel="Sélectionner une période"
-								onResetDate={handleResetDateRange}
-								defaultValue={undefined}
-								onValueChange={dateRange => handleOnPeriodChange(dateRange)}
-							/>
+					{activeTab === 'general' && (
+						<div className="flex space-x-2">
+							<div className="hidden sm:block">
+								<DateRangePicker
+									defaultLabel="Sélectionner une période"
+									onResetDate={handleResetDateRange}
+									defaultValue={undefined}
+									onValueChange={dateRange => handleOnPeriodChange(dateRange)}
+								/>
+							</div>
+							<Button
+								className="hidden sm:block"
+								variant={'primary'}
+								disabled={!(from && to)}
+								onClick={handleFilter}
+							>
+								Filtrer
+							</Button>
 						</div>
+					)}
+				</Header>
+			}
+		>
+			<div className="flex flex-col gap-5">
+				{activeTab === 'general' && (
+					<div className="sm:hidden flex space-x-2">
+						<DateRangePicker
+							defaultLabel="Sélectionner une période"
+							onResetDate={handleResetDateRange}
+							defaultValue={undefined}
+							onValueChange={dateRange => handleOnPeriodChange(dateRange)}
+							className="w-full"
+						/>
 						<Button
-							className="hidden sm:block"
 							variant={'primary'}
 							disabled={!(from && to)}
 							onClick={handleFilter}
@@ -121,42 +177,16 @@ export default function Birthday() {
 							Filtrer
 						</Button>
 					</div>
-				</Header>
-			}
-		>
-			<div className="flex flex-col gap-5">
-				<div className="sm:hidden flex space-x-2">
-					<DateRangePicker
-						defaultLabel="Sélectionner une période"
-						onResetDate={handleResetDateRange}
-						defaultValue={undefined}
-						onValueChange={dateRange => handleOnPeriodChange(dateRange)}
-						className="w-full"
-					/>
-					<Button variant={'primary'} disabled={!(from && to)}>
-						Filtrer
-					</Button>
-				</div>
-				<Card className="space-y-2 pb-4 mb-2">
-					<BirthdayTable
-						data={data.birthdays}
-						entityType={entityType[0]}
-						canSeeAll={data.userPermissions.canSeeAll}
-						onSeeMember={handleBirthdayDetails}
-					/>
-					<div className="flex justify-center pb-2">
-						<Button
-							size="sm"
-							type="button"
-							variant="ghost"
-							disabled={data.filterData.take >= data.totalCount}
-							className="bg-neutral-200 rounded-full"
-							onClick={handleDisplayMore}
-						>
-							Voir plus
-						</Button>
-					</div>
-				</Card>
+				)}
+
+				<Tabs value={activeTab} onValueChange={handleTabChange}>
+					<TabsList>
+						<TabsTrigger value="general">Général</TabsTrigger>
+						<TabsTrigger value="week">Cette semaine</TabsTrigger>
+					</TabsList>
+					<TabsContent value="general">{birthdayCard}</TabsContent>
+					<TabsContent value="week">{birthdayCard}</TabsContent>
+				</Tabs>
 
 				{openDetails && selectedMember && (
 					<BirthdayMemberDetails

--- a/app/routes/_dashboard/birthdays/loader.server.ts
+++ b/app/routes/_dashboard/birthdays/loader.server.ts
@@ -5,6 +5,7 @@ import { getAllBirthdays, getEntitiesBirthdays } from './utils.server'
 import { parseWithZod } from '@conform-to/zod'
 import { filterSchema } from './schema'
 import invariant from 'tiny-invariant'
+import { endOfWeek, startOfWeek } from 'date-fns'
 
 export async function loaderFn({ request }: LoaderFunctionArgs) {
 	const user = await requireUser(request)
@@ -16,6 +17,12 @@ export async function loaderFn({ request }: LoaderFunctionArgs) {
 	invariant(submission.status === 'success', 'filter params must be defined')
 
 	const { value } = submission
+
+	if (value.tab === 'week') {
+		const monday = startOfWeek(new Date(), { weekStartsOn: 1 })
+		value.from = monday.toISOString()
+		value.to = endOfWeek(new Date(), { weekStartsOn: 1 }).toISOString()
+	}
 
 	const canSeeAll =
 		user.roles.includes('ADMIN') || user.roles.includes('SUPER_ADMIN')

--- a/app/routes/_dashboard/birthdays/schema.ts
+++ b/app/routes/_dashboard/birthdays/schema.ts
@@ -1,16 +1,17 @@
-import { endOfWeek, startOfWeek } from 'date-fns'
+import { endOfMonth, startOfMonth } from 'date-fns'
 import { z } from 'zod'
 import { DEFAULT_QUERY_TAKE } from '~/shared/constants'
 
 export const filterSchema = z.object({
 	from: z
 		.string()
-		.default(startOfWeek(new Date(), { weekStartsOn: 1 }).toISOString()),
+		.default(startOfMonth(new Date()).toISOString()),
 	to: z
 		.string()
-		.default(endOfWeek(new Date(), { weekStartsOn: 1 }).toISOString()),
+		.default(endOfMonth(new Date()).toISOString()),
 	take: z.number().default(DEFAULT_QUERY_TAKE),
 	page: z.number().default(1),
+	tab: z.enum(['general', 'week']).default('general'),
 })
 
 export type FilterSchema = z.infer<typeof filterSchema>

--- a/app/routes/_dashboard/birthdays/utils.server.ts
+++ b/app/routes/_dashboard/birthdays/utils.server.ts
@@ -53,12 +53,13 @@ export async function getAllBirthdays(
 				},
 			},
 		},
-		orderBy: [{ name: 'asc' }],
 	})
 
-	const filteredMembers = members.filter(
-		m => m.birthday && isBirthdayInWeek(m.birthday, startDate, endDate),
-	)
+	const filteredMembers = members
+		.filter(m => m.birthday && isBirthdayInWeek(m.birthday, startDate, endDate))
+		.sort((a, b) =>
+			sortBirthdayDesc(a.birthday!, b.birthday!, startDate.getFullYear()),
+		)
 
 	const totalCount = filteredMembers.length
 	const offset = (page - 1) * take
@@ -175,7 +176,13 @@ export async function getEntitiesBirthdays(
 		})
 	}
 
-	birthdays.sort((a, b) => a.name.localeCompare(b.name))
+	birthdays.sort((a, b) =>
+		sortBirthdayDesc(
+			new Date(a.birthday),
+			new Date(b.birthday),
+			startDate.getFullYear(),
+		),
+	)
 
 	return { birthdays, entities, totalCount: birthdays.length }
 }
@@ -224,14 +231,22 @@ async function fetchEntityBirthdays(params: {
 		},
 	})
 
-	const filteredMembers = membersRaw.filter(
-		m => m.birthday && isBirthdayInWeek(m.birthday, startDate, endDate),
-	)
+	const filteredMembers = membersRaw
+		.filter(m => m.birthday && isBirthdayInWeek(m.birthday, startDate, endDate))
+		.sort((a, b) =>
+			sortBirthdayDesc(a.birthday!, b.birthday!, startDate.getFullYear()),
+		)
 
 	const offset = (page - 1) * take
 	const paginated = filteredMembers.slice(offset, offset + take)
 
 	return formatMemberData(paginated)
+}
+
+function sortBirthdayDesc(a: Date, b: Date, year: number): number {
+	const dateA = new Date(year, a.getMonth(), a.getDate()).getTime()
+	const dateB = new Date(year, b.getMonth(), b.getDate()).getTime()
+	return dateB - dateA
 }
 
 function isBirthdayInWeek(

--- a/app/shared/menus-links.ts
+++ b/app/shared/menus-links.ts
@@ -80,7 +80,7 @@ export const rolesMenuLinks: RoleSidebarLinks[] = [
 			},
 			{
 				to: '/archives',
-				label: 'Archives',
+				label: 'Archivages',
 				Icon: RiUserForbidLine,
 			},
 			{
@@ -115,7 +115,7 @@ export const rolesMenuLinks: RoleSidebarLinks[] = [
 			},
 			{
 				to: '/archives-request',
-				label: "Demande d'archives",
+				label: "Demande d'archivage",
 				Icon: RiUserForbidLine,
 			},
 			{
@@ -150,7 +150,7 @@ export const rolesMenuLinks: RoleSidebarLinks[] = [
 			},
 			{
 				to: '/archives-request',
-				label: "Demande d'archives",
+				label: "Demande d'archivage",
 				Icon: RiUserForbidLine,
 			},
 			{
@@ -180,7 +180,7 @@ export const rolesMenuLinks: RoleSidebarLinks[] = [
 			},
 			{
 				to: '/archives-request',
-				label: "Demande d'archives",
+				label: "Demande d'archivage",
 				Icon: RiUserForbidLine,
 			},
 			{


### PR DESCRIPTION
## What?

- Fix member birthday listing and implement archive request edition/deletion.
- **Modified files/modules:**
  - `app/routes/_dashboard/birthdays/` — birthday listing page, loader, schema, utils
  - `app/routes/_dashboard/archives-request/` — archive request list, form dialog, table, action, hooks, schema
  - `app/components/form/month-picker.tsx` — minor fix
  - `app/shared/menus-links.ts` — navigation update
- **New behaviors:**
  - Birthday page now has two tabs: "General" (filterable by date range) and "Week" (current week's birthdays); date range filter is hidden when the Week tab is active
  - Archive requests can now be edited and deleted directly from the list
- **Removed behaviors:**
  - Inline edit/delete hooks removed from the archives detail page (`archives.($id)`)

## Why?

- The birthday listing was not correctly scoping results; users needed a quick view of the current week's birthdays without manually filtering
- Archive requests lacked edit/delete capabilities, forcing users to recreate entries for corrections

## How?

- Added a `tab` search param (`general` | `week`) to the birthdays route; the loader filters results accordingly via `utils.server.ts`
- Refactored `reloadData` to accept `Record<string, unknown>` so tab state is preserved alongside date filters
- Extended `action.server.ts` in archives-request to handle `EDIT` and `DELETE` intents with Zod-validated schemas
- `archive-form-dialog.tsx` and `main-form.tsx` updated to support pre-filled values for editing
- `use-archives-request.ts` hook extended with `onEdit` and `onDelete` callbacks wired to the table columns

## Testing?

- Unit tests added/updated: no
- Integration / end-to-end tests: no
- Manual steps to verify locally:
  1. Navigate to `/birthdays` — confirm both tabs render and switch correctly
  2. On the "General" tab, apply a date range filter and confirm results update
  3. On the "Week" tab, confirm the date range filter is hidden and only current-week birthdays appear
  4. Navigate to `/archives-request` — open the edit dialog on an existing request, modify fields, save, and confirm changes persist
  5. Delete an archive request and confirm it is removed from the list
- CI status: pending

## Anything Else?

- No database migrations required
- The `archives.($id)` edit/delete hooks were removed; that functionality now lives exclusively in the request list view

## Checklist

- [ ] I added/updated tests (unit/integration)
- [ ] I updated documentation where necessary
- [ ] I ran the full test suite locally and it passes
- [ ] I verified this change in a staging environment (if applicable)
- [ ] This change requires a migration and I updated migration docs (if applicable)
