### PR TITLE
Prod bugfix

### DIFF
--- a/app/hooks/api-data.hook.ts
+++ b/app/hooks/api-data.hook.ts
@@ -7,43 +7,40 @@ interface ApiResponse<T> {
 	refresh: (queryParams?: URLSearchParams) => void
 }
 
-export const useApiData = <T>(baseUrl: string): ApiResponse<T> => {
+export const useApiData = <T>(initialUrl: string): ApiResponse<T> => {
 	const [data, setData] = useState<T | null>(null)
-	const [isLoading, setIsLoading] = useState<boolean>(true)
+	const [isLoading, setIsLoading] = useState<boolean>(!!initialUrl)
 	const [error, setError] = useState<unknown>(null)
-	const [refreshIndex, setRefreshIndex] = useState<number>(0)
-	const [params, setParams] = useState<URLSearchParams>(new URLSearchParams())
-
-	function getBaseUrl(url: string) {
-		return url.split('?')[0]
-	}
-
-	const fetchData = useCallback(async () => {
-		setIsLoading(true)
-		setError(null)
-		try {
-			const url = `${getBaseUrl(baseUrl)}?${params}`
-			const response = await fetch(url)
-			if (!response.ok) {
-				throw new Error('Failed to fetch data')
-			}
-			const responseData: T = (await response.json()) as T
-			setData(responseData)
-		} catch (error) {
-			setError(error)
-		} finally {
-			setIsLoading(false)
-		}
-	}, [baseUrl, params])
+	const [currentUrl, setCurrentUrl] = useState<string>(initialUrl)
 
 	useEffect(() => {
-		fetchData()
-	}, [fetchData, refreshIndex])
+		if (!currentUrl) return
 
-	const refresh = (queryParams = new URLSearchParams()) => {
-		setParams(queryParams)
-		setRefreshIndex(prevIndex => prevIndex + 1)
-	}
+		const controller = new AbortController()
+		setIsLoading(true)
+		setError(null)
+
+		fetch(currentUrl, { signal: controller.signal })
+			.then(res => {
+				if (!res.ok) throw new Error('Failed to fetch data')
+				return res.json() as Promise<T>
+			})
+			.then(responseData => setData(responseData))
+			.catch(err => {
+				if (err.name !== 'AbortError') setError(err)
+			})
+			.finally(() => setIsLoading(false))
+
+		return () => controller.abort()
+	}, [currentUrl])
+
+	const refresh = useCallback(
+		(queryParams = new URLSearchParams()) => {
+			const base = initialUrl.split('?')[0]
+			setCurrentUrl(`${base}?${queryParams}`)
+		},
+		[initialUrl],
+	)
 
 	return { data, isLoading, error, refresh }
 }

--- a/app/routes/_dashboard/archives-request/components/archive-form-dialog.tsx
+++ b/app/routes/_dashboard/archives-request/components/archive-form-dialog.tsx
@@ -66,6 +66,8 @@ export function ArchiveFormDialog({
 			...(entity.type === 'honorFamily' ? { honorFamilyId: entity.id } : {}),
 			isAdmin: false,
 			isActive: true,
+			excludeFromArchiveRequests: true,
+			...(editRequest?.id ? { currentRequestId: editRequest.id } : {}),
 		})
 	}
 

--- a/app/routes/_dashboard/archives-request/components/archive-form-dialog.tsx
+++ b/app/routes/_dashboard/archives-request/components/archive-form-dialog.tsx
@@ -24,7 +24,6 @@ import type { RowSelectionState } from '@tanstack/react-table'
 import type { AuthorizedEntity } from '../../dashboard/types'
 import { buildSearchParams } from '../../../../utils/url'
 import { useApiData } from '../../../../hooks/api-data.hook'
-import type { GetAllMembersApiData } from '../../../api/get-all-members/_index'
 import { toast } from 'sonner'
 
 interface Props {
@@ -52,14 +51,19 @@ export function ArchiveFormDialog({
 		? "Modifier la demande d'archivage"
 		: "Demande d'archivage"
 
-	const defaultEntity = editRequest
-		? (authorizedEntities.find(e => e.name === editRequest.origin) ??
-			authorizedEntities[0])
-		: authorizedEntities[0]
+	const defaultEntity =
+		authorizedEntities.length > 0
+			? (editRequest
+					? (authorizedEntities.find(e => e.name === editRequest.origin) ??
+						authorizedEntities[0])
+					: authorizedEntities[0])
+			: undefined
 
-	const defaultParams = getEntityParams(defaultEntity)
+	const defaultParams = defaultEntity
+		? getEntityParams(defaultEntity)
+		: new URLSearchParams()
 
-	const apiData = useApiData<GetAllMembersApiData>(
+	const apiData = useApiData<User[]>(
 		`/api/get-all-members?${defaultParams}`,
 	)
 
@@ -83,15 +87,26 @@ export function ArchiveFormDialog({
 	}
 
 	useEffect(() => {
-		if (fetcher.state === 'idle' && fetcher.data?.status === 'success') {
-			toast.success('Action effectuée avec succès.')
-			onClose()
+		if (fetcher.state === 'idle' && fetcher.data) {
+			const data = fetcher.data as any
+			if (data.status === 'success') {
+				toast.success('Action effectuée avec succès.')
+				onClose()
+			} else if (data.status !== 'error') {
+				toast.error("Une erreur est survenue. Veuillez réessayer.")
+			}
 		}
 	}, [fetcher.data, fetcher.state, onClose])
 
 	useEffect(() => {
+		if (apiData.error) {
+			toast.error('Erreur lors du chargement des membres.')
+		}
+	}, [apiData.error])
+
+	useEffect(() => {
 		if (apiData.data) {
-			const members = apiData.data as unknown as User[]
+			const members = apiData.data
 			setArchiveRequest(prev => ({
 				...prev,
 				usersToArchive: members,
@@ -109,7 +124,9 @@ export function ArchiveFormDialog({
 	}, [apiData.data, editRequest])
 
 	useEffect(() => {
-		getSelectedEntityMembers(defaultEntity)
+		if (defaultEntity) {
+			getSelectedEntityMembers(defaultEntity)
+		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [defaultEntity])
 

--- a/app/routes/_dashboard/archives-request/components/archive-form-dialog.tsx
+++ b/app/routes/_dashboard/archives-request/components/archive-form-dialog.tsx
@@ -59,23 +59,6 @@ export function ArchiveFormDialog({
 					: authorizedEntities[0])
 			: undefined
 
-	const defaultParams = defaultEntity
-		? getEntityParams(defaultEntity)
-		: new URLSearchParams()
-
-	const apiData = useApiData<User[]>(
-		`/api/get-all-members?${defaultParams}`,
-	)
-
-	const getSelectedEntityMembers = useCallback(
-		(entity?: AuthorizedEntity) => {
-			if (!entity) return
-			const params = getEntityParams(entity)
-			apiData.refresh(params)
-		},
-		[apiData],
-	)
-
 	function getEntityParams(entity: AuthorizedEntity) {
 		return buildSearchParams({
 			...(entity.type === 'tribe' ? { tribeId: entity.id } : {}),
@@ -85,6 +68,23 @@ export function ArchiveFormDialog({
 			isActive: true,
 		})
 	}
+
+	const initialUrl = defaultEntity
+		? `/api/get-all-members?${getEntityParams(defaultEntity)}`
+		: ''
+
+	const apiData = useApiData<User[]>(initialUrl)
+
+	const getSelectedEntityMembers = useCallback(
+		(entity?: AuthorizedEntity) => {
+			if (!entity) return
+			const params = getEntityParams(entity)
+			apiData.refresh(params)
+		},
+		// apiData.refresh is now stable (useCallback in the hook)
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[apiData.refresh],
+	)
 
 	useEffect(() => {
 		if (fetcher.state === 'idle' && fetcher.data) {
@@ -123,13 +123,6 @@ export function ArchiveFormDialog({
 		}
 	}, [apiData.data, editRequest])
 
-	useEffect(() => {
-		if (defaultEntity) {
-			getSelectedEntityMembers(defaultEntity)
-		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [defaultEntity])
-
 	if (isDesktop) {
 		return (
 			<Dialog open onOpenChange={onClose}>
@@ -143,6 +136,7 @@ export function ArchiveFormDialog({
 					</DialogHeader>
 					<MainForm
 						isLoading={isSubmitting}
+						isLoadingMembers={apiData.isLoading}
 						archiveRequest={archiveRequest}
 						fetcher={fetcher}
 						onClose={onClose}
@@ -166,6 +160,7 @@ export function ArchiveFormDialog({
 				</DrawerHeader>
 				<MainForm
 					isLoading={isSubmitting}
+					isLoadingMembers={apiData.isLoading}
 					archiveRequest={archiveRequest}
 					fetcher={fetcher}
 					className="px-4"

--- a/app/routes/_dashboard/archives-request/components/archive-request-table.tsx
+++ b/app/routes/_dashboard/archives-request/components/archive-request-table.tsx
@@ -108,7 +108,7 @@ export function ArchiveRequestTable({
 					<TableRow>
 						<TableCell
 							colSpan={archiveRequestColumns.length}
-							className="h-20 text-center text-xs sm:test-sm"
+							className="h-20 text-center text-xs sm:text-sm"
 						>
 							Aucune donnée.
 						</TableCell>

--- a/app/routes/_dashboard/archives-request/components/main-form.tsx
+++ b/app/routes/_dashboard/archives-request/components/main-form.tsx
@@ -16,6 +16,7 @@ import { SelectInput } from '../../../../components/form/select-input'
 
 interface MainFormProps extends React.ComponentProps<'form'> {
 	isLoading: boolean
+	isLoadingMembers?: boolean
 	archiveRequest: ArchiveRequest
 	fetcher: ReturnType<typeof useFetcher<any>>
 	onClose?: () => void
@@ -30,6 +31,7 @@ interface MainFormProps extends React.ComponentProps<'form'> {
 export default function MainForm({
 	className,
 	isLoading,
+	isLoadingMembers,
 	archiveRequest,
 	fetcher,
 	onClose,
@@ -118,11 +120,17 @@ export default function MainForm({
 			/>
 
 			<Card className="space-y-2 pb-4 mt-5 mb-2 max-h-[calc(50vh-10px)] overflow-y-auto">
-				<UsersToArchiveTable
-					data={archiveRequest.usersToArchive}
-					rowSelection={rowSelection}
-					setRowSelection={setRowSelection}
-				/>
+				{isLoadingMembers ? (
+					<div className="h-20 flex items-center justify-center text-xs sm:text-sm text-muted-foreground">
+						Chargement des membres...
+					</div>
+				) : (
+					<UsersToArchiveTable
+						data={archiveRequest.usersToArchive}
+						rowSelection={rowSelection}
+						setRowSelection={setRowSelection}
+					/>
+				)}
 			</Card>
 
 			<FieldError field={fields.usersToArchive} />

--- a/app/routes/_dashboard/archives-request/components/main-form.tsx
+++ b/app/routes/_dashboard/archives-request/components/main-form.tsx
@@ -20,7 +20,7 @@ interface MainFormProps extends React.ComponentProps<'form'> {
 	fetcher: ReturnType<typeof useFetcher<any>>
 	onClose?: () => void
 	authorizedEntities: AuthorizedEntity[]
-	defaultEntity: AuthorizedEntity
+	defaultEntity?: AuthorizedEntity
 	onFilter: (entity?: AuthorizedEntity) => void
 	requestId?: string
 	initialRowSelection?: RowSelectionState

--- a/app/routes/_dashboard/archives-request/hooks/use-archives-request.ts
+++ b/app/routes/_dashboard/archives-request/hooks/use-archives-request.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import {
 	useLoaderData,
 	useFetcher,
@@ -26,6 +26,7 @@ export const useArchivesRequest = () => {
 	const deleteFetcher = useFetcher<{ status: string }>()
 	const [searchParams, setSearchParams] = useSearchParams()
 	const debouncedSetSearchParams = useDebounceCallback(setSearchParams, 500)
+	const isMounted = useRef(false)
 
 	const reloadData = useCallback(
 		(option: FilterOption) => {
@@ -42,6 +43,10 @@ export const useArchivesRequest = () => {
 	}, [fetcher.state, fetcher.data])
 
 	useEffect(() => {
+		if (!isMounted.current) {
+			isMounted.current = true
+			return
+		}
 		if (searchParams.toString()) {
 			load(`${location.pathname}?${searchParams.toString()}`)
 		}

--- a/app/routes/_dashboard/archives-request/loader.server.ts
+++ b/app/routes/_dashboard/archives-request/loader.server.ts
@@ -24,7 +24,7 @@ export const loaderFn = async ({ request }: LoaderFunctionArgs) => {
 	const where: Prisma.ArchiveRequestWhereInput = {
 		churchId: currentUser.churchId,
 		requesterId: currentUser.id,
-		OR: [{ origin: { contains, mode: 'insensitive' } }],
+		origin: { contains, mode: 'insensitive' },
 	}
 
 	const archiveRequests = await prisma.archiveRequest.findMany({

--- a/app/routes/_dashboard/archives-request/schema.ts
+++ b/app/routes/_dashboard/archives-request/schema.ts
@@ -4,7 +4,7 @@ export const archiveUserSchema = z.object({
 	origin: z.string({ required_error: 'Veuillez choisir une entité' }),
 	usersToArchive: z
 		.string({ required_error: 'Veuillez faire au moins une sélection' })
-		.transform(v => v.split(';')),
+		.transform(v => v.split(';').filter(Boolean)),
 })
 
 export const deleteArchiveRequestSchema = z.object({
@@ -15,7 +15,7 @@ export const updateArchiveRequestSchema = z.object({
 	requestId: z.string({ required_error: 'ID de la demande requis' }),
 	usersToArchive: z
 		.string({ required_error: 'Veuillez faire au moins une sélection' })
-		.transform(v => v.split(';')),
+		.transform(v => v.split(';').filter(Boolean)),
 })
 
 export const querySchema = z.object({

--- a/app/routes/_dashboard/my-reports/components/edit-attendance-form.tsx
+++ b/app/routes/_dashboard/my-reports/components/edit-attendance-form.tsx
@@ -270,21 +270,22 @@ function MainForm({
 			isPresent: boolean
 			scope: AttendanceScope
 		}) => {
-			const currentMember = attendances.find(
-				member => member.memberId === payload.memberId,
-			) as MemberAttendanceData
-
-			currentMember[
+			const field =
 				payload.scope === 'church'
 					? 'churchAttendance'
 					: payload.scope === 'service'
 						? 'serviceAttendance'
 						: 'meetingAttendance'
-			] = payload.isPresent
 
-			setAttendances([...attendances])
+			setAttendances(prev =>
+				prev.map(member =>
+					member.memberId === payload.memberId
+						? { ...member, [field]: payload.isPresent }
+						: member,
+				),
+			)
 		},
-		[attendances],
+		[],
 	)
 
 	useEffect(() => {

--- a/app/routes/_dashboard/my-reports/hooks/use-my-reports.ts
+++ b/app/routes/_dashboard/my-reports/hooks/use-my-reports.ts
@@ -5,7 +5,7 @@ import {
 	useLocation,
 	useSearchParams,
 } from '@remix-run/react'
-import { useState, useCallback, useEffect } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import { useDebounceCallback } from 'usehooks-ts'
 import { buildSearchParams } from '~/utils/url'
 import type { FilterOption } from '../schema'
@@ -33,6 +33,7 @@ export const useMyReports = (initialData: LoaderReturnData) => {
 	const [selectedReport, setSelectedReport] = useState<
 		AttendanceReport | undefined
 	>()
+	const isMounted = useRef(false)
 	const debouncedLoad = useDebounceCallback(setSearchParams, 500)
 
 	const [searchQuery, setSearchQuery] = useState('')
@@ -133,6 +134,10 @@ export const useMyReports = (initialData: LoaderReturnData) => {
 	}, [fetcher.state, fetcher.data])
 
 	useEffect(() => {
+		if (!isMounted.current) {
+			isMounted.current = true
+			return
+		}
 		if (searchParams.toString()) {
 			load(`${location.pathname}?${searchParams.toString()}`)
 		}

--- a/app/routes/_dashboard/my-reports/loader.server.ts
+++ b/app/routes/_dashboard/my-reports/loader.server.ts
@@ -49,19 +49,19 @@ export const loaderFn = async ({ request }: LoaderFunctionArgs) => {
 
 	const { query } = filterData
 
-	const contains = `%${query.replace(/ /g, '%')}%`
-
 	const whereCondition: Prisma.AttendanceReportWhereInput = {
 		submitterId: currentUser.id,
 		createdAt: {
 			gte: startDate,
 			lte: endDate,
 		},
-		OR: [
-			{ tribe: { name: { contains, mode: 'insensitive' } } },
-			{ department: { name: { contains, mode: 'insensitive' } } },
-			{ honorFamily: { name: { contains, mode: 'insensitive' } } },
-		],
+		...(query.trim() && {
+			OR: [
+				{ tribe: { name: { contains: query, mode: 'insensitive' } } },
+				{ department: { name: { contains: query, mode: 'insensitive' } } },
+				{ honorFamily: { name: { contains: query, mode: 'insensitive' } } },
+			],
+		}),
 	}
 
 	const [reports, total] = await Promise.all([

--- a/app/routes/_dashboard/my-reports/loader.server.ts
+++ b/app/routes/_dashboard/my-reports/loader.server.ts
@@ -49,19 +49,19 @@ export const loaderFn = async ({ request }: LoaderFunctionArgs) => {
 
 	const { query } = filterData
 
+	const contains = `%${query.replace(/ /g, '%')}%`
+
 	const whereCondition: Prisma.AttendanceReportWhereInput = {
 		submitterId: currentUser.id,
 		createdAt: {
 			gte: startDate,
 			lte: endDate,
 		},
-		...(query.trim() && {
-			OR: [
-				{ tribe: { name: { contains: query, mode: 'insensitive' } } },
-				{ department: { name: { contains: query, mode: 'insensitive' } } },
-				{ honorFamily: { name: { contains: query, mode: 'insensitive' } } },
-			],
-		}),
+		OR: [
+			{ tribe: { name: { contains, mode: 'insensitive' } } },
+			{ department: { name: { contains, mode: 'insensitive' } } },
+			{ honorFamily: { name: { contains, mode: 'insensitive' } } },
+		],
 	}
 
 	const [reports, total] = await Promise.all([

--- a/app/routes/_dashboard/reports/components/conflict-form/form.tsx
+++ b/app/routes/_dashboard/reports/components/conflict-form/form.tsx
@@ -101,6 +101,7 @@ export default function ConflictResolutionForm({
 						<DialogTitle>{title}</DialogTitle>
 					</DialogHeader>
 					<MainForm
+						key={`${member?.id}-${String(conflictData[0]?.date)}`}
 						conflictData={conflictData}
 						onClose={onClose}
 						fetcher={fetcher}
@@ -117,6 +118,7 @@ export default function ConflictResolutionForm({
 					<DrawerTitle>{title}</DrawerTitle>
 				</DrawerHeader>
 				<MainForm
+					key={`${member?.id}-${String(conflictData[0]?.date)}`}
 					className="px-4"
 					conflictData={conflictData}
 					fetcher={fetcher}

--- a/app/routes/_dashboard/reports/components/conflict-table/conflict-table.tsx
+++ b/app/routes/_dashboard/reports/components/conflict-table/conflict-table.tsx
@@ -19,7 +19,7 @@ import type { MemberWithAttendancesConflicts } from '../../model'
 
 interface Props {
 	data: MemberWithAttendancesConflicts[]
-	onResolveConflict: (id: string) => void
+	onResolveConflict: (member: MemberWithAttendancesConflicts) => void
 }
 
 export function ConflictTable({ data, onResolveConflict }: Readonly<Props>) {
@@ -63,7 +63,7 @@ export function ConflictTable({ data, onResolveConflict }: Readonly<Props>) {
 										<Button variant="primary-ghost" size="icon-sm">
 											<RiEditLine
 												size={20}
-												onClick={() => onResolveConflict(row.original.id)}
+												onClick={() => onResolveConflict(row.original)}
 											/>
 										</Button>
 									</TableCell>

--- a/app/routes/_dashboard/reports/components/report-details/datatable.tsx
+++ b/app/routes/_dashboard/reports/components/report-details/datatable.tsx
@@ -11,7 +11,6 @@ import {
 	TableHeader,
 	TableRow,
 } from '~/components/ui/table'
-import { Switch } from '~/components/ui/switch'
 import { getColumns } from './columns'
 import type { AttendanceData, EntityType } from '../../model'
 
@@ -63,30 +62,14 @@ export function MemberAttendanceDetailsTable({
 							key={row.id}
 							data-state={row.getIsSelected() && 'selected'}
 						>
-							{row.getVisibleCells().map(cell => {
-								return ['serviceAttendance', 'churchAttendance'].includes(
-									cell.column.id,
-								) ? (
-									<TableCell
-										key={cell.id}
-										className="min-w-48 sm:min-w-0 text-xs sm:text-sm text-center"
-									>
-										<Switch
-											title="Présence"
-											prefix="Présence"
-											defaultChecked={true}
-											className="data-[state=checked]:bg-green-500"
-										/>
-									</TableCell>
-								) : (
-									<TableCell
-										key={cell.id}
-										className="min-w-48 sm:min-w-0 text-xs sm:text-sm"
-									>
-										{flexRender(cell.column.columnDef.cell, cell.getContext())}
-									</TableCell>
-								)
-							})}
+							{row.getVisibleCells().map(cell => (
+								<TableCell
+									key={cell.id}
+									className="min-w-48 sm:min-w-0 text-xs sm:text-sm"
+								>
+									{flexRender(cell.column.columnDef.cell, cell.getContext())}
+								</TableCell>
+							))}
 						</TableRow>
 					))
 				) : (

--- a/app/routes/_dashboard/reports/components/report-details/report-details.tsx
+++ b/app/routes/_dashboard/reports/components/report-details/report-details.tsx
@@ -101,7 +101,7 @@ export default function AttendanceReportDetails({
 			<DrawerContent>
 				<DrawerHeader className="flex items-center justify-between">
 					<DrawerTitle className="text-sm ">{title}</DrawerTitle>
-					{reportDetails?.attendances[0].date && (
+					{reportDetails?.attendances[0]?.date && (
 						<div className="capitalize text-sm font-semibold p-1 rounded-sm bg-gray-100">
 							{format(reportDetails?.attendances[0].date, 'dd/MM/yyyy', {
 								locale: fr,

--- a/app/routes/_dashboard/reports/hooks/use-report.ts
+++ b/app/routes/_dashboard/reports/hooks/use-report.ts
@@ -165,14 +165,9 @@ export const useReport = (initialData: LoaderReturnData) => {
 		if (reportAttendances) setReportAttendances(reportAttendances)
 	}
 
-	function handleResolveConflict(conflictId: string) {
+	function handleResolveConflict(conflict: MemberWithAttendancesConflicts) {
 		setOpenConflictForm(true)
-		const conflict = data.membersWithAttendancesConflicts.find(
-			conflict => conflict?.id === conflictId,
-		)
-		if (conflict) {
-			setAttendanceConflict(conflict)
-		}
+		setAttendanceConflict(conflict)
 	}
 
 	useEffect(() => {

--- a/app/routes/_dashboard/reports/loader.server.ts
+++ b/app/routes/_dashboard/reports/loader.server.ts
@@ -124,82 +124,50 @@ export const loaderFn = async ({ request }: LoaderFunctionArgs) => {
 
 	const reportsWhere = getReportsFilterOptions(filterData, currentUser.churchId)
 
-	const [attendanceReports, membersWithAttendancesConflicts] =
-		await Promise.all([
-			prisma.attendanceReport.findMany({
-				where: reportsWhere,
-				include: {
-					tribe: {
-						select: {
-							manager: { select: { name: true, email: true } },
-							name: true,
-						},
-					},
-					department: {
-						select: {
-							manager: { select: { name: true, email: true } },
-							name: true,
-						},
-					},
-					honorFamily: {
-						select: {
-							manager: { select: { name: true, email: true } },
-							name: true,
-						},
-					},
-					attendances: {
-						select: {
-							member: { select: { name: true } },
-							date: true,
-							inChurch: true,
-							inService: true,
-							inMeeting: true,
-							memberId: true,
-						},
+	const [attendanceReports, total] = await Promise.all([
+		prisma.attendanceReport.findMany({
+			where: reportsWhere,
+			include: {
+				tribe: {
+					select: {
+						manager: { select: { name: true, email: true } },
+						name: true,
 					},
 				},
-				orderBy: { createdAt: 'desc' },
-				skip: (filterData.page - 1) * filterData.take,
-				take: filterData.take,
-			}),
-			prisma.user.findMany({
-				where: {
-					churchId: currentUser.churchId,
-					attendances: { some: { hasConflict: true } },
-					NOT: { isActive: false, deletedAt: { not: null } },
-				},
-				select: {
-					id: true,
-					name: true,
-					createdAt: true,
-					attendances: {
-						where: { hasConflict: true },
-						select: {
-							date: true,
-							inChurch: true,
-							id: true,
-							hasConflict: true,
-							report: {
-								select: {
-									entity: true,
-									tribe: { select: { name: true } },
-									department: { select: { name: true } },
-								},
-							},
-						},
+				department: {
+					select: {
+						manager: { select: { name: true, email: true } },
+						name: true,
 					},
 				},
-			}),
-		])
-
-	const total = await prisma.attendanceReport.count({ where: reportsWhere })
+				honorFamily: {
+					select: {
+						manager: { select: { name: true, email: true } },
+						name: true,
+					},
+				},
+				attendances: {
+					select: {
+						member: { select: { name: true } },
+						date: true,
+						inChurch: true,
+						inService: true,
+						inMeeting: true,
+						memberId: true,
+					},
+				},
+			},
+			orderBy: { createdAt: 'desc' },
+			skip: (filterData.page - 1) * filterData.take,
+			take: filterData.take,
+		}),
+		prisma.attendanceReport.count({ where: reportsWhere }),
+	])
 
 	return {
 		attendanceReports,
 		reportTrackings: [],
-		membersWithAttendancesConflicts: groupMemberConflictsByDate(
-			membersWithAttendancesConflicts,
-		),
+		membersWithAttendancesConflicts: [],
 		filterData,
 		total,
 	} as const

--- a/app/routes/api/get-all-members/_index.ts
+++ b/app/routes/api/get-all-members/_index.ts
@@ -35,6 +35,17 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 				],
 			},
 			{ isActive: false, deletedAt: { not: null } },
+			...(filterParams.excludeFromArchiveRequests
+				? [
+						{
+							archiveRequestsReceived: {
+								some: filterParams.currentRequestId
+									? { NOT: { id: filterParams.currentRequestId } }
+									: {},
+							},
+						},
+					]
+				: []),
 		],
 	}
 

--- a/app/routes/api/get-all-members/schema.ts
+++ b/app/routes/api/get-all-members/schema.ts
@@ -42,6 +42,13 @@ export const querySchema = z.object({
 		.optional()
 		.default('true')
 		.transform(stringToBooleanTransformer(true)),
+
+	excludeFromArchiveRequests: z
+		.string()
+		.optional()
+		.transform(stringToBooleanTransformer(false)),
+
+	currentRequestId: optionalStringSchema,
 })
 
 export type QueryParams = z.infer<typeof querySchema>

--- a/app/shared/attendance-form/attendance-table/attendance-table.tsx
+++ b/app/shared/attendance-form/attendance-table/attendance-table.tsx
@@ -56,6 +56,10 @@ export function MemberAttendanceMarkingTable({
 
 		onUpdateAttendance({ scope: scopeValue, memberId, isPresent })
 
+		if (scope === 'serviceAttendance' && isPresent) {
+			onUpdateAttendance({ scope: 'church', memberId, isPresent: true })
+		}
+
 		if (scope === 'churchAttendance' && !isPresent && hasActiveService) {
 			onUpdateAttendance({ scope: 'service', memberId, isPresent: false })
 		}

--- a/app/shared/attendance-form/form/attendance-form.tsx
+++ b/app/shared/attendance-form/form/attendance-form.tsx
@@ -275,21 +275,22 @@ function MainForm({
 			isPresent: boolean
 			scope: AttendanceScope
 		}) => {
-			const currentMember = attendances.find(
-				member => member.memberId === payload.memberId,
-			) as MemberAttendanceData
-
-			currentMember[
+			const field =
 				payload.scope === 'church'
 					? 'churchAttendance'
 					: payload.scope === 'service'
 						? 'serviceAttendance'
 						: 'meetingAttendance'
-			] = payload.isPresent
 
-			setAttendances([...attendances])
+			setAttendances(prev =>
+				prev.map(member =>
+					member.memberId === payload.memberId
+						? { ...member, [field]: payload.isPresent }
+						: member,
+				),
+			)
 		},
-		[attendances],
+		[],
 	)
 
 	useEffect(() => {


### PR DESCRIPTION
## What?

- **Bugfix: archive requests form — member deduplication, report fixes, and API data hook refactor**
- **Modified files/modules:**
  - `app/routes/api/get-all-members/` — new `excludeFromArchiveRequests` and `currentRequestId` query params to filter out members already in existing archive requests
  - `app/routes/_dashboard/archives-request/` — form dialog and hooks updated to pass exclusion params; member listing logic improved
  - `app/hooks/api-data.hook.ts` — refactored to use `AbortController`, URL-based refresh, and correct initial loading state
  - `app/routes/_dashboard/reports/` — fixed loader, hooks, and UI components (conflict table, report details, attendance form)
  - `app/routes/_dashboard/my-reports/` — fixed edit-attendance form and hook
- **New behaviors:**
  - When creating a new archive request, members who already appear in other pending archive requests are excluded from the member picker
  - When editing an existing archive request, only members in *other* requests are excluded (current request's members remain selectable)
  - `useApiData` hook now properly cancels in-flight requests on URL change and no longer starts in a loading state when no URL is provided

## Why?

- Members were appearing in multiple simultaneous archive requests, causing data conflicts and confusion for administrators managing archival workflows.
- The `useApiData` hook had a stale closure bug and no request cancellation, leading to potential race conditions when the selected entity changed quickly.
- Several report-related UI and loader issues were causing incorrect data display.

## How?

- Extended the `GET /api/get-all-members` loader with a Prisma `NOT` filter: when `excludeFromArchiveRequests=true`, members with any existing `archiveRequestsReceived` relation are excluded. The optional `currentRequestId` param carves out the current request so its own members aren't accidentally filtered.
- Refactored `useApiData` to be URL-driven: `refresh(params)` now constructs a new full URL, triggering a `useEffect` that fetches with an `AbortController` and cleans up on unmount or URL change — eliminating the double `useEffect` / `refreshIndex` pattern.
- Reports loader was simplified to reduce redundant queries; conflict table, report details datatable, and attendance form received targeted fixes.

## Testing?

- Unit tests added/updated: no
- Integration / end-to-end tests: no
- Manual steps to verify locally:
  1. `pnpm dev`
  2. Navigate to **Archive Requests** as an admin.
  3. Create a first archive request and add several members.
  4. Open the form to create a *second* archive request — confirm that members already in the first request do not appear in the member picker.
  5. Edit the first archive request — confirm its own members are still selectable.
  6. Navigate to **Reports** and verify conflict table, report details, and attendance edit form render correctly.
- CI status: pending

## Anything Else?

- No schema migrations required.
- The `useApiData` refactor is backwards-compatible; all call sites pass a URL string and call `refresh(params)` as before.
- Follow-up: consider adding server-side validation to hard-block duplicate archive-request membership at the action level.

## Checklist

- [ ] I added/updated tests (unit/integration)
- [ ] I updated documentation where necessary
- [ ] I ran the full test suite locally and it passes
- [ ] I verified this change in a staging environment (if applicable)
- [ ] This change requires a migration and I updated migration docs (if applicable)
