### PR TITLE
Entity bugfix

### DIFF
--- a/app/helpers/integration.server.ts
+++ b/app/helpers/integration.server.ts
@@ -104,7 +104,7 @@ async function updateManagerIntegrationDate(
 		where: { id: oldManagerId },
 		select: {
 			roles: true,
-			password: true, // Ajouter cette ligne pour vérifier si l'utilisateur a un mot de passe
+			password: true,
 		},
 	})
 
@@ -252,6 +252,24 @@ async function hashPassword(password: string) {
 	})
 
 	return hashedPassword
+}
+
+export async function fetchEntityMemberIds(
+	entityType: EntityType,
+	entityId: string,
+): Promise<string[]> {
+	const select = { members: { select: { id: true } } }
+
+	if (entityType === 'tribe') {
+		const entity = await prisma.tribe.findUnique({ where: { id: entityId }, select })
+		return entity?.members.map(m => m.id) ?? []
+	}
+	if (entityType === 'department') {
+		const entity = await prisma.department.findUnique({ where: { id: entityId }, select })
+		return entity?.members.map(m => m.id) ?? []
+	}
+	const entity = await prisma.honorFamily.findUnique({ where: { id: entityId }, select })
+	return entity?.members.map(m => m.id) ?? []
 }
 
 export async function selectMembers(memberIds: string[] | undefined) {

--- a/app/routes/_dashboard/departments.($id)/server/actions/action.server.ts
+++ b/app/routes/_dashboard/departments.($id)/server/actions/action.server.ts
@@ -51,8 +51,10 @@ export const actionFn = async ({ request, params }: ActionFunctionArgs) => {
 		})
 
 		return { status: 'success' }
-	} catch (error: any) {
-		return { ...submission.reply(), status: 'error', error: error.cause }
+	} catch (error: unknown) {
+		const message =
+			error instanceof Error ? error.message : 'Une erreur inattendue est survenue'
+		return { ...submission.reply(), status: 'error', error: message }
 	}
 }
 

--- a/app/routes/_dashboard/departments.($id)/server/actions/handler.server.ts
+++ b/app/routes/_dashboard/departments.($id)/server/actions/handler.server.ts
@@ -105,6 +105,9 @@ export async function handleDepartment({
 async function getMemberData(payload: DepartmentFormData) {
 	const manager = await fetchManagerMemberData(payload.managerId, prisma)
 	const { data, errors } = await handleMemberSelection(payload, prisma)
-	if (errors.length > 0) throw new Error('Invalid data', { cause: errors })
+	if (errors.length > 0) {
+		const message = errors.join(' | ')
+		throw new Error(message)
+	}
 	return removeDuplicateMembers([manager, ...data])
 }

--- a/app/routes/_dashboard/departments_.$id.details/server/action.server.ts
+++ b/app/routes/_dashboard/departments_.$id.details/server/action.server.ts
@@ -9,7 +9,7 @@ import { type Prisma, Role } from '@prisma/client'
 import invariant from 'tiny-invariant'
 import { uploadMembers } from '~/utils/member'
 import { hash } from '@node-rs/argon2'
-import { updateIntegrationDates } from '~/helpers/integration.server'
+import { fetchEntityMemberIds, updateIntegrationDates } from '~/helpers/integration.server'
 import { saveMemberPicture } from '~/helpers/member-picture.server'
 import { createEntityMemberSchema } from '~/shared/schema'
 import {
@@ -174,22 +174,24 @@ async function uploadDepartmentMembers(
 	churchId: string,
 	departmentId: string,
 ) {
-	const uploadedMembers = await uploadMembers(file, churchId)
+	const [uploadedMembers, currentMemberIds] = await Promise.all([
+		uploadMembers(file, churchId),
+		fetchEntityMemberIds('department', departmentId),
+	])
+
+	const newMemberIds = uploadedMembers.map(m => m.id)
+
 	await prisma.$transaction(async tx => {
-		await prisma.department.update({
+		await tx.department.update({
 			where: { id: departmentId },
-			data: {
-				members: {
-					connect: uploadedMembers.map(member => ({ id: member.id })),
-				},
-			},
+			data: { members: { connect: newMemberIds.map(id => ({ id })) } },
 		})
 
 		await updateIntegrationDates({
 			tx: tx as unknown as Prisma.TransactionClient,
 			entityType: 'department',
-			newMemberIds: [...uploadedMembers.map(m => m.id)],
-			currentMemberIds: [],
+			newMemberIds,
+			currentMemberIds,
 		})
 	})
 }

--- a/app/routes/_dashboard/honor-families.$id_.details/utils/utils.server.ts
+++ b/app/routes/_dashboard/honor-families.$id_.details/utils/utils.server.ts
@@ -11,7 +11,7 @@ import type {
 	GetHonorFamilyAssistantsData,
 	CreateMemberData,
 } from '../types'
-import { updateIntegrationDates } from '~/helpers/integration.server'
+import { fetchEntityMemberIds, updateIntegrationDates } from '~/helpers/integration.server'
 import { parseWithZod } from '@conform-to/zod'
 import { createFile } from '~/utils/xlsx.server'
 import { transformMembersDataForExport } from '~/shared/attendance'
@@ -109,23 +109,24 @@ export async function uploadHonorFamilyMembers(
 	churchId: string,
 	honorFamilyId: string,
 ) {
-	const uploadedMembers = await uploadMembers(file, churchId)
+	const [uploadedMembers, currentMemberIds] = await Promise.all([
+		uploadMembers(file, churchId),
+		fetchEntityMemberIds('honorFamily', honorFamilyId),
+	])
+
+	const newMemberIds = uploadedMembers.map(m => m.id)
 
 	await prisma.$transaction(async tx => {
-		await prisma.honorFamily.update({
+		await tx.honorFamily.update({
 			where: { id: honorFamilyId },
-			data: {
-				members: {
-					connect: uploadedMembers.map(member => ({ id: member.id })),
-				},
-			},
+			data: { members: { connect: newMemberIds.map(id => ({ id })) } },
 		})
 
 		await updateIntegrationDates({
 			tx: tx as unknown as Prisma.TransactionClient,
 			entityType: 'honorFamily',
-			newMemberIds: [...uploadedMembers.map(m => m.id)],
-			currentMemberIds: [],
+			newMemberIds,
+			currentMemberIds,
 		})
 	})
 }

--- a/app/routes/_dashboard/honor-families.($id)/_index.tsx
+++ b/app/routes/_dashboard/honor-families.($id)/_index.tsx
@@ -2,6 +2,7 @@ import {
 	type MetaFunction,
 	useFetcher,
 	useLoaderData,
+	useLocation,
 	useSearchParams,
 } from '@remix-run/react'
 import { useState } from 'react'
@@ -39,15 +40,16 @@ export default function HonorFamily() {
 		HonorFamilyData | undefined
 	>(undefined)
 
+	const location = useLocation()
 	const debounced = useDebounceCallback(setSearchParams, 500)
 
 	useDownloadFile(fetcher, { isExporting, setIsExporting })
 
-	const handleClose = (shouldReloade: boolean) => {
+	const handleClose = (shouldReload: boolean) => {
 		setOpenEditForm(false)
 		setSelectedHonorFamily(undefined)
 
-		if (shouldReloade) fetcher.load(`${location.pathname}?${searchParams}`)
+		if (shouldReload) fetcher.load(`${location.pathname}?${searchParams}`)
 	}
 
 	const handleEdit = (honorFamilie: HonorFamilyData) => {

--- a/app/routes/_dashboard/honor-families.($id)/schema.ts
+++ b/app/routes/_dashboard/honor-families.($id)/schema.ts
@@ -72,36 +72,3 @@ export const memberSchema = z.object({
 	}),
 	location: z.string(),
 })
-
-export const editHonorFamilySchema = z.object({
-	name: z.string({
-		required_error: "Le nom de la famille d'honneur est requis",
-	}),
-	location: z.string({ required_error: 'La localisation est requise' }),
-	managerId: z.string({ required_error: 'Sélectionner un responsable' }),
-	managerEmail: z
-		.string()
-		.email('Veuillez entrer une adresse email valide.')
-		.optional(),
-	password: z
-		.string({ required_error: PWD_ERROR_MESSAGE.min })
-		.min(8, PWD_ERROR_MESSAGE.min)
-		.regex(PWD_REGEX, PWD_ERROR_MESSAGE.invalid)
-		.optional(),
-	membersId: z
-		.string()
-		.transform(data => JSON.parse(data) as string[])
-		.optional(),
-	membersFile: z
-		.instanceof(File)
-		.optional()
-		.refine(file => {
-			if (file) {
-				return [
-					'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-					'application/vnd.ms-excel',
-				].includes(file.type)
-			}
-			return true
-		}, 'Le fichier doit être de type Excel (.xlsx ou .xls)'),
-})

--- a/app/routes/_dashboard/honor-families.($id)/server/action.server.ts
+++ b/app/routes/_dashboard/honor-families.($id)/server/action.server.ts
@@ -89,10 +89,8 @@ async function createHonorFamily(
 ) {
 	await prisma.$transaction(async tx => {
 		const uploadedMembers = await uploadMembers(data.membersFile, churchId)
-
 		const selectedMembers = await selectMembers(data.memberIds)
-
-		const members = [...uploadedMembers, ...selectedMembers]
+		const members = deduplicateById([...uploadedMembers, ...selectedMembers])
 
 		const honorFamily = await tx.honorFamily.create({
 			data: {
@@ -159,7 +157,7 @@ async function editHonorFamily(
 
 		const uploadedMembers = await uploadMembers(membersFile, churchId)
 		const selectedMembers = await selectMembers(memberIds)
-		const members = [...uploadedMembers, ...selectedMembers]
+		const members = deduplicateById([...uploadedMembers, ...selectedMembers])
 
 		await handleEntityManagerUpdate({
 			tx: tx as unknown as Prisma.TransactionClient,
@@ -196,6 +194,10 @@ async function editHonorFamily(
 			],
 		})
 	})
+}
+
+function deduplicateById<T extends { id: string }>(items: T[]): T[] {
+	return Array.from(new Map(items.map(item => [item.id, item])).values())
 }
 
 export type ActionData = typeof actionFn

--- a/app/routes/_dashboard/honor-family/utils/utils.server.ts
+++ b/app/routes/_dashboard/honor-family/utils/utils.server.ts
@@ -17,7 +17,7 @@ import type {
 } from '../types'
 import { getMonthSundays, normalizeDate } from '~/utils/date'
 import { STATUS } from '../constants'
-import { updateIntegrationDates } from '~/helpers/integration.server'
+import { fetchEntityMemberIds, updateIntegrationDates } from '~/helpers/integration.server'
 import { parseWithZod } from '@conform-to/zod'
 import { createFile } from '~/utils/xlsx.server'
 import { transformMembersDataForExport } from '~/shared/attendance'
@@ -101,23 +101,24 @@ export async function uploadHonorFamilyMembers(
 	churchId: string,
 	honorFamilyId: string,
 ) {
-	const uploadedMembers = await uploadMembers(file, churchId)
+	const [uploadedMembers, currentMemberIds] = await Promise.all([
+		uploadMembers(file, churchId),
+		fetchEntityMemberIds('honorFamily', honorFamilyId),
+	])
+
+	const newMemberIds = uploadedMembers.map(m => m.id)
 
 	await prisma.$transaction(async tx => {
-		await prisma.honorFamily.update({
+		await tx.honorFamily.update({
 			where: { id: honorFamilyId },
-			data: {
-				members: {
-					connect: uploadedMembers.map(member => ({ id: member.id })),
-				},
-			},
+			data: { members: { connect: newMemberIds.map(id => ({ id })) } },
 		})
 
 		await updateIntegrationDates({
 			tx: tx as unknown as Prisma.TransactionClient,
 			entityType: 'honorFamily',
-			newMemberIds: [...uploadedMembers.map(m => m.id)],
-			currentMemberIds: [],
+			newMemberIds,
+			currentMemberIds,
 		})
 	})
 }

--- a/app/routes/_dashboard/members.($id)/server/actions/action-handlers/upload-members.ts
+++ b/app/routes/_dashboard/members.($id)/server/actions/action-handlers/upload-members.ts
@@ -89,15 +89,38 @@ async function upsertMembers(members: MemberData[], churchId: string) {
 			}
 
 			const user = await prisma.user.findFirst({
-				where: {
-					name: { equals: member.name, mode: 'insensitive' },
+				where: { name: { equals: member.name, mode: 'insensitive' } },
+				select: {
+					id: true,
+					tribeId: true,
+					departmentId: true,
+					honorFamilyId: true,
 				},
 			})
 
 			if (user) {
+				const now = new Date()
+				const integrationDateFields: Record<string, Date | null> = {}
+				if (tribeId && tribeId !== user.tribeId)
+					integrationDateFields.tribeDate = now
+				if (dptId && dptId !== user.departmentId)
+					integrationDateFields.departementDate = now
+				if (familyId && familyId !== user.honorFamilyId)
+					integrationDateFields.familyDate = now
+
 				await prisma.user.update({
 					where: { id: user.id },
-					data: payload,
+					data: {
+						...payload,
+						...(Object.keys(integrationDateFields).length > 0 && {
+							integrationDate: {
+								upsert: {
+									create: integrationDateFields,
+									update: integrationDateFields,
+								},
+							},
+						}),
+					},
 				})
 
 				updated++

--- a/app/routes/_dashboard/members.($id)/server/actions/action.server.ts
+++ b/app/routes/_dashboard/members.($id)/server/actions/action.server.ts
@@ -95,21 +95,61 @@ async function editMember({ id, churchId, intent, data }: EditMemberPayload) {
 	const pictureUrl = picture ? await saveMemberPicture(picture) : null
 	const isUpdate = intent === FORM_INTENT.EDIT
 
-	const payload = {
-		...rest,
-		...(!isUpdate && {
-			roles: [Role.MEMBER],
-			church: { connect: { id: churchId } },
-		}),
-		...(pictureUrl && { pictureUrl }),
+	const entityConnections = {
 		...(tribeId && { tribe: { connect: { id: tribeId } } }),
 		...(departmentId && { department: { connect: { id: departmentId } } }),
 		...(honorFamilyId && { honorFamily: { connect: { id: honorFamilyId } } }),
 	}
 
-	return isUpdate && id
-		? prisma.user.update({ where: { id }, data: payload })
-		: prisma.user.create({ data: payload })
+	if (!isUpdate || !id) {
+		return prisma.user.create({
+			data: {
+				...rest,
+				roles: [Role.MEMBER],
+				church: { connect: { id: churchId } },
+				...(pictureUrl && { pictureUrl }),
+				...entityConnections,
+				integrationDate: {
+					create: {
+						tribeDate: tribeId ? new Date() : null,
+						departementDate: departmentId ? new Date() : null,
+						familyDate: honorFamilyId ? new Date() : null,
+					},
+				},
+			},
+		})
+	}
+
+	const currentMember = await prisma.user.findUnique({
+		where: { id },
+		select: { tribeId: true, departmentId: true, honorFamilyId: true },
+	})
+
+	const now = new Date()
+	const integrationDateFields: Record<string, Date | null> = {}
+	if (tribeId && tribeId !== currentMember?.tribeId)
+		integrationDateFields.tribeDate = now
+	if (departmentId && departmentId !== currentMember?.departmentId)
+		integrationDateFields.departementDate = now
+	if (honorFamilyId && honorFamilyId !== currentMember?.honorFamilyId)
+		integrationDateFields.familyDate = now
+
+	return prisma.user.update({
+		where: { id },
+		data: {
+			...rest,
+			...(pictureUrl && { pictureUrl }),
+			...entityConnections,
+			...(Object.keys(integrationDateFields).length > 0 && {
+				integrationDate: {
+					upsert: {
+						create: integrationDateFields,
+						update: integrationDateFields,
+					},
+				},
+			}),
+		},
+	})
 }
 
 async function exportMembers(request: Request, currentUser: AuthenticatedUser) {

--- a/app/routes/_dashboard/tribe/action.server.ts
+++ b/app/routes/_dashboard/tribe/action.server.ts
@@ -7,7 +7,7 @@ import { FORM_INTENT } from '~/shared/constants'
 import { createEntityMemberSchema, uploadMemberSchema } from '~/shared/schema'
 import { requireUser } from '~/utils/auth.server'
 import { prisma } from '~/infrastructures/database/prisma.server'
-import { updateIntegrationDates } from '~/helpers/integration.server'
+import { fetchEntityMemberIds, updateIntegrationDates } from '~/helpers/integration.server'
 import { uploadMembers } from '~/utils/member'
 import { saveMemberPicture } from '~/helpers/member-picture.server'
 import { notifyAdminForAddedMemberInEntity } from '~/helpers/notification.server'
@@ -147,23 +147,24 @@ async function uploadTribeMembers(
 	churchId: string,
 	tribeId: string,
 ) {
-	const uploadedMembers = await uploadMembers(file, churchId)
+	const [uploadedMembers, currentMemberIds] = await Promise.all([
+		uploadMembers(file, churchId),
+		fetchEntityMemberIds('tribe', tribeId),
+	])
+
+	const newMemberIds = uploadedMembers.map(m => m.id)
 
 	await prisma.$transaction(async tx => {
-		await prisma.tribe.update({
+		await tx.tribe.update({
 			where: { id: tribeId },
-			data: {
-				members: {
-					connect: uploadedMembers.map(member => ({ id: member.id })),
-				},
-			},
+			data: { members: { connect: newMemberIds.map(id => ({ id })) } },
 		})
 
 		await updateIntegrationDates({
 			tx: tx as unknown as Prisma.TransactionClient,
 			entityType: 'tribe',
-			newMemberIds: [...uploadedMembers.map(m => m.id)],
-			currentMemberIds: [],
+			newMemberIds,
+			currentMemberIds,
 		})
 	})
 }

--- a/app/routes/_dashboard/tribes.($id)/server/action.server.ts
+++ b/app/routes/_dashboard/tribes.($id)/server/action.server.ts
@@ -143,7 +143,7 @@ async function createTribe(
 	await prisma.$transaction(async tx => {
 		const uploadedMembers = await uploadMembers(membersFile, churchId)
 		const selectedMembers = await selectMembers(memberIds)
-		const members = [...uploadedMembers, ...selectedMembers]
+		const members = deduplicateById([...uploadedMembers, ...selectedMembers])
 
 		const tribe = await tx.tribe.create({
 			data: {
@@ -201,7 +201,7 @@ async function updateTribe(
 
 		const uploadedMembers = await uploadMembers(membersFile, churchId)
 		const selectedMembers = await selectMembers(memberIds)
-		const members = [...uploadedMembers, ...selectedMembers]
+		const members = deduplicateById([...uploadedMembers, ...selectedMembers])
 
 		if (currentTribe.managerId !== tribeManagerId) {
 			await handleEntityManagerUpdate({
@@ -238,6 +238,10 @@ async function updateTribe(
 			currentMemberIds: [...members.map(m => m.id), tribeManagerId],
 		})
 	})
+}
+
+function deduplicateById<T extends { id: string }>(items: T[]): T[] {
+	return Array.from(new Map(items.map(item => [item.id, item])).values())
 }
 
 export type ActionType = typeof actionFn

--- a/app/routes/_dashboard/tribes.($id)/server/action.server.ts
+++ b/app/routes/_dashboard/tribes.($id)/server/action.server.ts
@@ -235,7 +235,7 @@ async function updateTribe(
 			newManagerId: tribeManagerId,
 			oldManagerId: currentTribe.managerId,
 			newMemberIds: members.map(m => m.id),
-			currentMemberIds: [...members.map(m => m.id), tribeManagerId],
+			currentMemberIds: currentTribe.members.map(m => m.id),
 		})
 	})
 }

--- a/app/routes/_dashboard/tribes_.$id.details/server/action.server.ts
+++ b/app/routes/_dashboard/tribes_.$id.details/server/action.server.ts
@@ -9,7 +9,7 @@ import { type Prisma, Role } from '@prisma/client'
 import invariant from 'tiny-invariant'
 import { uploadMembers } from '~/utils/member'
 import { hash } from '@node-rs/argon2'
-import { updateIntegrationDates } from '~/helpers/integration.server'
+import { fetchEntityMemberIds, updateIntegrationDates } from '~/helpers/integration.server'
 import { createEntityMemberSchema } from '~/shared/schema'
 import { saveMemberPicture } from '~/helpers/member-picture.server'
 import type { ExportMembersPayload } from '../types'
@@ -219,23 +219,24 @@ async function uploadTribeMembers(
 	churchId: string,
 	tribeId: string,
 ) {
-	const uploadedMembers = await uploadMembers(file, churchId)
+	const [uploadedMembers, currentMemberIds] = await Promise.all([
+		uploadMembers(file, churchId),
+		fetchEntityMemberIds('tribe', tribeId),
+	])
+
+	const newMemberIds = uploadedMembers.map(m => m.id)
 
 	await prisma.$transaction(async tx => {
-		await prisma.tribe.update({
+		await tx.tribe.update({
 			where: { id: tribeId },
-			data: {
-				members: {
-					connect: uploadedMembers.map(member => ({ id: member.id })),
-				},
-			},
+			data: { members: { connect: newMemberIds.map(id => ({ id })) } },
 		})
 
 		await updateIntegrationDates({
 			tx: tx as unknown as Prisma.TransactionClient,
 			entityType: 'tribe',
-			newMemberIds: [...uploadedMembers.map(m => m.id)],
-			currentMemberIds: [],
+			newMemberIds,
+			currentMemberIds,
 		})
 	})
 }


### PR DESCRIPTION
## What?

- Fix and extend integration date tracking across all entity modules (tribe, department, honor family)
- **Modified files/modules:**
  - `app/helpers/integration.server.ts` — shared integration date helper
  - `app/routes/_dashboard/members.($id)/server/actions/action.server.ts` — member create/edit action
  - `app/routes/_dashboard/members.($id)/server/actions/action-handlers/upload-members.ts` — bulk upload handler
  - `app/routes/_dashboard/tribe/action.server.ts`, `tribes.($id)/server/action.server.ts`, `tribes_.$id.details/server/action.server.ts` — tribe module
  - `app/routes/_dashboard/department/...`, `honor-family/...` — department and honor family modules
- **New behaviors:**
  - On member **creation**, `integrationDate` is now created with the relevant `tribeDate`, `departementDate`, and `familyDate` set to the current timestamp.
  - On member **edit** (form or bulk upload), integration dates are updated **only when the assigned entity changes** (not on every save), using an upsert on `integrationDate`.
  - Same logic applied consistently across tribe, department, and honor-family manager flows.

## Why?

- Integration dates were missing or not updated when a member changed tribe/department/honor family assignment.
- Business requirement: track when a member joined each entity for reporting and history purposes.
- The upsert-only-on-change approach avoids overwriting valid historical dates on unrelated edits.

## How?

- On create: always write `integrationDate.create` with the current date for each assigned entity.
- On update: fetch the current member's entity IDs, compare with incoming values, and build a partial `integrationDateFields` map — only fields that changed are included in the upsert.
- The same pattern is reused across the bulk upload handler and all entity-specific action servers for consistency.
- No schema migration needed; `integrationDate` model already exists.

## Testing?

- Unit tests added/updated: no
- Integration / end-to-end tests: no
- Manual steps to verify locally:
  1. Create a new member assigned to a tribe/department/honor family → verify `integrationDate` record is created with today's date.
  2. Edit the member without changing the tribe → verify `tribeDate` is unchanged.
  3. Edit the member and assign a different tribe → verify `tribeDate` is updated to today.
  4. Bulk-upload a member sheet with changed entity assignments → verify integration dates are updated only for changed entities.
- CI status: pending

## Anything Else?

- The `departementDate` field name follows the existing (intentional) typo in the Prisma schema.
- No backwards-compatibility concerns; the upsert handles both existing and missing `integrationDate` records.

## Checklist

- [ ] I added/updated tests (unit/integration)
- [ ] I updated documentation where necessary
- [ ] I ran the full test suite locally and it passes
- [ ] I verified this change in a staging environment (if applicable)
- [ ] This change requires a migration and I updated migration docs (if applicable)
