### PR TITLE
feat: add export's ability to tribe and department manager

### DIFF
--- a/app/routes/_dashboard/department/_index.tsx
+++ b/app/routes/_dashboard/department/_index.tsx
@@ -8,6 +8,7 @@ import SpeedDialMenu, {
 	type SpeedDialAction,
 } from '~/components/layout/mobile/speed-dial-menu'
 import { loaderFn } from './server/loader.server'
+import { actionFn } from './server/action.server'
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -16,6 +17,7 @@ import {
 } from '~/components/ui/dropdown-menu'
 import { useDepartment } from './hooks/use-department'
 import { useLoaderData } from '@remix-run/react'
+import { useDownloadFile } from '~/shared/hooks'
 import UploadFormDialog from '../departments_.$id.details/components/form/upload-member-form'
 import { EditMemberForm } from '../departments_.$id.details/components/form/edit-member-form'
 import AttendanceFormDialog from '../../../shared/attendance-form/form/attendance-form'
@@ -46,6 +48,7 @@ const SPEED_DIAL_ITEMS: SpeedDialAction[] = [
 export const meta: MetaFunction = () => [{ title: 'Jeriel | Mon départment' }]
 
 export const loader = loaderFn
+export const action = actionFn
 
 export default function Department() {
 	const loaderData = useLoaderData<typeof loaderFn>()
@@ -54,14 +57,17 @@ export default function Department() {
 		data,
 		view,
 		currentMonth,
+		isExporting,
 		openFilterForm,
 		openUploadForm,
 		openManualForm,
 		openAttendanceForm,
+		downloadFetcher,
 		setView,
 		handleClose,
 		handleSearch,
 		handleExport,
+		setIsExporting,
 		setOpenManualForm,
 		setOpenFilterForm,
 		setOpenUploadForm,
@@ -69,6 +75,8 @@ export default function Department() {
 		setOpenAttendanceForm,
 		handleShowMoreTableData,
 	} = useDepartment(loaderData)
+
+	useDownloadFile(downloadFetcher, { isExporting, setIsExporting })
 
 	function handleSpeedDialMenuAction(action: string) {
 		if (action === SPEED_DIAL_ACTIONS.ADD_MEMBER) setOpenManualForm(true)
@@ -124,6 +132,8 @@ export default function Department() {
 					onSearch={view !== 'STAT' ? handleSearch : undefined}
 					onFilter={view !== 'STAT' ? () => setOpenFilterForm(true) : undefined}
 					onExport={view !== 'STAT' ? handleExport : undefined}
+					isExporting={isExporting}
+					canExport={data.membersAttendances.length > 0}
 				/>
 			</div>
 			<Card className="space-y-2 pb-4 mb-2">

--- a/app/routes/_dashboard/department/constants.ts
+++ b/app/routes/_dashboard/department/constants.ts
@@ -1,0 +1,3 @@
+export const FORM_INTENT = {
+	EXPORT: 'export_members',
+}

--- a/app/routes/_dashboard/department/hooks/use-department.ts
+++ b/app/routes/_dashboard/department/hooks/use-department.ts
@@ -8,14 +8,17 @@ import { useDebounceCallback } from 'usehooks-ts'
 import type { MemberFilterOptions } from '../models'
 import { buildSearchParams } from '~/utils/url'
 import type { LoaderType } from '../server/loader.server'
+import type { ActionType } from '../server/action.server'
 import type { ViewOption } from '~/components/toolbar'
 import { startOfMonth } from 'date-fns'
+import { FORM_INTENT } from '../constants'
 
 type LoaderReturnData = ReturnType<typeof useLoaderData<LoaderType>>
 
 export const useDepartment = (initialData: LoaderReturnData) => {
 	const [data, setData] = useState(initialData)
 	const { load, ...fetcher } = useFetcher<LoaderType>()
+	const downloadFetcher = useFetcher<ActionType>()
 	const [searchParams, setSearchParams] = useSearchParams()
 
 	const [view, setView] = useState<ViewOption>('CULTE')
@@ -26,6 +29,7 @@ export const useDepartment = (initialData: LoaderReturnData) => {
 	const [openFilterForm, setOpenFilterForm] = useState(false)
 	const [openAttendanceForm, setOpenAttendanceForm] = useState(false)
 	const [currentMonth, setCurrentMonth] = useState(new Date())
+	const [isExporting, setIsExporting] = useState(false)
 
 	const debounced = useDebounceCallback(setSearchParams, 500)
 
@@ -75,7 +79,10 @@ export const useDepartment = (initialData: LoaderReturnData) => {
 		reloadData({ ...data.filterData, page: 1 })
 	}, [data.filterData, reloadData])
 
-	const handleExport = useCallback(() => {}, [])
+	const handleExport = useCallback(() => {
+		setIsExporting(true)
+		downloadFetcher.submit({ intent: FORM_INTENT.EXPORT }, { method: 'POST' })
+	}, [downloadFetcher])
 
 	useEffect(() => {
 		if (data.filterData.from && data.filterData.to) {
@@ -97,15 +104,18 @@ export const useDepartment = (initialData: LoaderReturnData) => {
 		data,
 		view,
 		currentMonth,
+		isExporting,
 		openManualForm,
 		openUploadForm,
 		openFilterForm,
 		openAssistantForm,
 		openAttendanceForm,
+		downloadFetcher,
 		setView,
 		handleClose,
 		handleExport,
 		handleSearch,
+		setIsExporting,
 		setOpenManualForm,
 		setOpenFilterForm,
 		setOpenUploadForm,

--- a/app/routes/_dashboard/department/server/action.server.ts
+++ b/app/routes/_dashboard/department/server/action.server.ts
@@ -1,0 +1,132 @@
+import { type ActionFunctionArgs } from '@remix-run/node'
+import { parseWithZod } from '@conform-to/zod'
+import { type Prisma } from '@prisma/client'
+import invariant from 'tiny-invariant'
+import { requireUser } from '~/utils/auth.server'
+import { prisma } from '~/infrastructures/database/prisma.server'
+import { normalizeDate } from '~/utils/date'
+import { MemberStatus } from '~/shared/enum'
+import {
+	buildMembersWithAttendances,
+	parseExportDateRanges,
+} from '~/helpers/attendance.server'
+import { createMembersExcelFile } from '~/utils/excel.server'
+import type { Member } from '~/models/member.model'
+import { FORM_INTENT } from '../constants'
+import { paramsSchema } from '../schema'
+
+export const actionFn = async ({ request }: ActionFunctionArgs) => {
+	const currentUser = await requireUser(request)
+	const { departmentId, churchId } = currentUser
+
+	invariant(churchId, 'Invalid churchId')
+	invariant(departmentId, 'departmentId is required')
+
+	const formData = await request.formData()
+	const intent = formData.get('intent')
+
+	if (intent === FORM_INTENT.EXPORT) {
+		return exportMembers(request, currentUser, departmentId)
+	}
+
+	return { status: 'success' }
+}
+
+export type ActionType = typeof actionFn
+
+function getUrlParams(request: Request) {
+	const url = new URL(request.url)
+	const submission = parseWithZod(url.searchParams, { schema: paramsSchema })
+	invariant(submission.status === 'success', 'invalid criteria')
+
+	return submission.value
+}
+
+async function getDepartmentName(id: string) {
+	return prisma.department.findFirst({
+		where: { id },
+		select: { name: true },
+	})
+}
+
+async function getExportDepartmentMembers(
+	departmentId: string,
+	filterData: ReturnType<typeof getUrlParams>,
+): Promise<Member[]> {
+	const contains = `%${filterData.query.replace(/ /g, '%')}%`
+
+	return prisma.user.findMany({
+		where: buildExportWhereInput(departmentId, filterData, contains),
+		select: {
+			id: true,
+			integrationDate: true,
+			name: true,
+			email: true,
+			phone: true,
+			location: true,
+			createdAt: true,
+			birthday: true,
+			gender: true,
+			maritalStatus: true,
+			pictureUrl: true,
+		},
+		orderBy: { name: 'asc' },
+	})
+}
+
+function buildExportWhereInput(
+	departmentId: string,
+	filterData: ReturnType<typeof getUrlParams>,
+	contains: string,
+): Prisma.UserWhereInput {
+	const { status, from, to } = filterData
+	const isEnabled = !!status && status !== 'ALL'
+	const isNew = status === MemberStatus.NEW
+	const startDate = normalizeDate(new Date(from), 'start')
+	const endDate = normalizeDate(new Date(to), 'end')
+
+	return {
+		departmentId,
+		isActive: true,
+		deletedAt: null,
+		OR: [{ name: { contains, mode: 'insensitive' } }, { phone: { contains } }],
+		...(isEnabled
+			? {
+					createdAt: isNew
+						? { gte: startDate, lte: endDate }
+						: { lte: startDate },
+				}
+			: { createdAt: { lte: endDate } }),
+	}
+}
+
+async function exportMembers(
+	request: Request,
+	currentUser: Awaited<ReturnType<typeof requireUser>>,
+	departmentId: string,
+) {
+	const filterData = getUrlParams(request)
+	const { fromDate, toDate, dateRanges } = parseExportDateRanges(filterData)
+	const department = await getDepartmentName(departmentId)
+
+	currentUser.tribeId = null
+	currentUser.honorFamilyId = null
+	currentUser.departmentId = departmentId
+
+	const members = await getExportDepartmentMembers(departmentId, filterData)
+	const membersWithAttendances = await buildMembersWithAttendances(
+		currentUser,
+		members,
+		fromDate,
+		dateRanges,
+	)
+
+	const fileName = `Membres du département ${department?.name ?? ''}`
+	const fileLink = await createMembersExcelFile(
+		membersWithAttendances,
+		toDate,
+		fileName,
+	)
+
+	return { status: 'success', fileLink: '/' + fileLink }
+}

--- a/app/routes/_dashboard/honor-family/server/action.server.ts
+++ b/app/routes/_dashboard/honor-family/server/action.server.ts
@@ -126,24 +126,31 @@ async function exportMembers(
 	honorFamilyId: string,
 ) {
 	const filterData = getUrlParams(request)
+
 	const { fromDate, toDate, dateRanges } = parseExportDateRanges(filterData)
+
 	const honorFamily = await getHonorFamilyName(honorFamilyId)
+
 	currentUser.honorFamilyId = honorFamilyId
+
 	const members = await getExportHonorFamilyMembers({
 		id: honorFamilyId,
 		filterData,
 	})
+
 	const membersWithAttendances = await buildMembersWithAttendances(
 		currentUser,
 		members,
 		fromDate,
 		dateRanges,
 	)
+
 	const fileName = `Membres de la famille d'Honneur ${honorFamily?.name}`
 	const fileLink = await createMembersExcelFile(
 		membersWithAttendances,
 		toDate,
 		fileName,
 	)
+
 	return { status: 'success', fileLink: '/' + fileLink }
 }

--- a/app/routes/_dashboard/tribe/_index.tsx
+++ b/app/routes/_dashboard/tribe/_index.tsx
@@ -7,6 +7,7 @@ import { useFetcher, useLoaderData } from '@remix-run/react'
 import { TableToolbar } from '~/components/toolbar'
 import { loaderFn } from './loader.server'
 import { useTribeMembers } from './hooks/use-tribe-members'
+import { useDownloadFile } from '~/shared/hooks'
 import { FilterForm } from '~/shared/forms/filter-form'
 import { DropdownMenuComponent } from '~/shared/forms/dropdown-menu'
 import SpeedDialMenu from '~/components/layout/mobile/speed-dial-menu'
@@ -32,15 +33,18 @@ export default function Tribe() {
 		data,
 		currentMonth,
 		view,
+		isExporting,
 		openFilterForm,
 		openCreateForm,
 		openUploadForm,
 		openAttendanceForm,
+		downloadFetcher,
 		setView,
 		handleSearch,
 		handleOnExport,
 		handleDisplayMore,
 		setOpenFilterForm,
+		setIsExporting,
 		handleOnFilter,
 		setOpenCreateForm,
 		setOpenUploadForm,
@@ -48,6 +52,8 @@ export default function Tribe() {
 		handleSpeedDialItemClick,
 		handleClose,
 	} = useTribeMembers(loaderData)
+
+	useDownloadFile(downloadFetcher, { isExporting, setIsExporting })
 
 	return (
 		<MainContent
@@ -80,6 +86,8 @@ export default function Tribe() {
 						onSearch={handleSearch}
 						onFilter={() => setOpenFilterForm(true)}
 						onExport={handleOnExport}
+						isExporting={isExporting}
+						canExport={data.members.length > 0}
 					/>
 				</div>
 				<Card className="space-y-2 pb-4 mb-2">

--- a/app/routes/_dashboard/tribe/action.server.ts
+++ b/app/routes/_dashboard/tribe/action.server.ts
@@ -14,6 +14,14 @@ import {
 import { uploadMembers } from '~/helpers/member-upload.server'
 import { saveMemberPicture } from '~/helpers/member-picture.server'
 import { notifyAdminForAddedMemberInEntity } from '~/helpers/notification.server'
+import {
+	buildMembersWithAttendances,
+	parseExportDateRanges,
+} from '~/helpers/attendance.server'
+import { createMembersExcelFile } from '~/utils/excel.server'
+import { TRIBE_FORM_INTENT } from './constants'
+import { getTribeName, getExportTribeMembers } from './utils.server'
+import { filterSchema } from './schema'
 
 const isPhoneExists = async ({
 	phone,
@@ -118,6 +126,8 @@ export const actionFn = async ({ request }: ActionFunctionArgs) => {
 	invariant(currentUser.churchId, 'Invalid churchId')
 	invariant(currentUser.tribeId, 'tribeId is required')
 	const { churchId, tribeId, id: managerId } = currentUser
+	if (intent === TRIBE_FORM_INTENT.EXPORT)
+		return exportMembers(request, currentUser, tribeId)
 	if (intent === FORM_INTENT.UPLOAD)
 		return handleUploadIntent(formData, churchId, tribeId)
 	if (intent === FORM_INTENT.CREATE)
@@ -141,6 +151,48 @@ async function createMember(
 			integrationDate: { create: { tribeDate: new Date() } },
 		},
 	})
+}
+
+function getUrlParams(request: Request) {
+	const url = new URL(request.url)
+	const submission = parseWithZod(url.searchParams, { schema: filterSchema })
+	invariant(submission.status === 'success', 'invalid criteria')
+	return submission.value
+}
+
+async function exportMembers(
+	request: Request,
+	currentUser: Awaited<ReturnType<typeof requireUser>>,
+	tribeId: string,
+) {
+	const filterData = getUrlParams(request)
+	const { fromDate, toDate, dateRanges } = parseExportDateRanges(filterData)
+	const tribe = await getTribeName(tribeId)
+
+	currentUser.departmentId = null
+	currentUser.honorFamilyId = null
+	currentUser.tribeId = tribeId
+
+	const members = await getExportTribeMembers(
+		tribeId,
+		currentUser.churchId!,
+		filterData,
+	)
+	const membersWithAttendances = await buildMembersWithAttendances(
+		currentUser,
+		members,
+		fromDate,
+		dateRanges,
+	)
+
+	const fileName = `Membres de la tribu ${tribe?.name ?? ''}`
+	const fileLink = await createMembersExcelFile(
+		membersWithAttendances,
+		toDate,
+		fileName,
+	)
+
+	return { status: 'success', fileLink: '/' + fileLink }
 }
 
 async function uploadTribeMembers(

--- a/app/routes/_dashboard/tribe/constants.ts
+++ b/app/routes/_dashboard/tribe/constants.ts
@@ -1,6 +1,10 @@
 import type { SpeedDialAction } from '~/components/layout/mobile/speed-dial-menu'
 import { RiAddLine, RiDashboardLine, RiFileExcel2Line } from '@remixicon/react'
 
+export const TRIBE_FORM_INTENT = {
+	EXPORT: 'export_members',
+}
+
 export const speedDialItemsActions = {
 	CREATE_MEMBER: 'create-member',
 	UPLOAD_MEMBERS: 'upload-member',

--- a/app/routes/_dashboard/tribe/hooks/use-tribe-members.ts
+++ b/app/routes/_dashboard/tribe/hooks/use-tribe-members.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import type { LoaderType } from '../loader.server'
+import type { ActionType } from '../action.server'
 import {
 	useFetcher,
 	type useLoaderData,
@@ -11,19 +12,21 @@ import { buildSearchParams } from '~/utils/url'
 import type { DateRange } from 'react-day-picker'
 import { startOfMonth } from 'date-fns'
 import { type ViewOption } from '~/components/toolbar'
-import { speedDialItemsActions } from '../constants'
+import { speedDialItemsActions, TRIBE_FORM_INTENT } from '../constants'
 
 type LoaderReturnData = ReturnType<typeof useLoaderData<LoaderType>>
 
 export function useTribeMembers(loaderData: LoaderReturnData) {
 	const [data, setData] = useState(loaderData)
 	const { load, ...fetcher } = useFetcher<LoaderType>()
+	const downloadFetcher = useFetcher<ActionType>()
 
 	const [view, setView] = useState<ViewOption>('CULTE')
 	const [openCreateForm, setOpenCreateForm] = useState(false)
 	const [openUploadForm, setOpenUploadForm] = useState(false)
 	const [openFilterForm, setOpenFilterForm] = useState(false)
 	const [currentMonth, setCurrentMonth] = useState(new Date())
+	const [isExporting, setIsExporting] = useState(false)
 	const [searchParams, setSearchParams] = useSearchParams()
 	const debounced = useDebounceCallback(setSearchParams, 500)
 	const [openAttendanceForm, setOpenAttendanceForm] = useState(false)
@@ -79,7 +82,13 @@ export function useTribeMembers(loaderData: LoaderReturnData) {
 		reloadData({ ...filterData, page: filterData.page + 1 })
 	}
 
-	function handleOnExport() {}
+	function handleOnExport() {
+		setIsExporting(true)
+		downloadFetcher.submit(
+			{ intent: TRIBE_FORM_INTENT.EXPORT },
+			{ method: 'POST' },
+		)
+	}
 
 	const handleSpeedDialItemClick = (action: string) => {
 		switch (action) {
@@ -114,10 +123,12 @@ export function useTribeMembers(loaderData: LoaderReturnData) {
 		data,
 		view,
 		fetcher,
+		isExporting,
 		openCreateForm,
 		openFilterForm,
 		openUploadForm,
 		openAttendanceForm,
+		downloadFetcher,
 		setOpenAttendanceForm,
 		currentMonth,
 		setView,
@@ -126,6 +137,7 @@ export function useTribeMembers(loaderData: LoaderReturnData) {
 		handleOnFilter,
 		handleOnExport,
 		handleDisplayMore,
+		setIsExporting,
 		setOpenCreateForm,
 		setOpenFilterForm,
 		setOpenUploadForm,

--- a/app/routes/_dashboard/tribe/utils.server.ts
+++ b/app/routes/_dashboard/tribe/utils.server.ts
@@ -2,6 +2,8 @@ import { type User, type Prisma } from '@prisma/client'
 import { normalizeDate } from '~/utils/date'
 import type { MemberFilterOptions } from './types'
 import { MemberStatus } from '~/shared/enum'
+import { prisma } from '~/infrastructures/database/prisma.server'
+import type { Member } from '~/models/member.model'
 
 export function getFilterOptions(
 	params: MemberFilterOptions,
@@ -52,4 +54,48 @@ export function formatOptions(options: MemberFilterOptions) {
 	}
 
 	return filterOptions
+}
+
+export async function getTribeName(id: string) {
+	return prisma.tribe.findFirst({
+		where: { id },
+		select: { name: true },
+	})
+}
+
+export async function getExportTribeMembers(
+	tribeId: string,
+	churchId: string,
+	filterData: MemberFilterOptions,
+): Promise<Member[]> {
+	const contains = `%${filterData.query.replace(/ /g, '%')}%`
+
+	return prisma.user.findMany({
+		where: {
+			churchId,
+			tribeId,
+			isActive: true,
+			deletedAt: null,
+			OR: [
+				{ name: { contains, mode: 'insensitive' } },
+				{ email: { contains, mode: 'insensitive' } },
+				{ phone: { contains } },
+			],
+			...getDateFilterOptions(filterData),
+		},
+		select: {
+			id: true,
+			integrationDate: true,
+			name: true,
+			email: true,
+			phone: true,
+			location: true,
+			createdAt: true,
+			birthday: true,
+			gender: true,
+			maritalStatus: true,
+			pictureUrl: true,
+		},
+		orderBy: { name: 'asc' },
+	})
 }


### PR DESCRIPTION
## What?

- Add Excel member export for department managers (`/department`) and tribe managers (`/tribe`).
- Modified modules:
  - `app/routes/_dashboard/department/` — new `constants.ts` and `server/action.server.ts`; updated `hooks/use-department.ts` and `_index.tsx`
  - `app/routes/_dashboard/tribe/` — updated `constants.ts`, `utils.server.ts`, `action.server.ts`, `hooks/use-tribe-members.ts` and `_index.tsx`
- New behavior: the "Export" button in the `TableToolbar` on both pages triggers the generation of a `.xlsx` file containing the member list with attendance data (current and previous month); the file is automatically downloaded on the client side.

## Why?

- Department and tribe managers could not export their member list from their dedicated views (`/department`, `/tribe`), unlike admins who already had this capability from the detail pages (`/departments/:id/details`, `/tribes/:id/details`).
- The `/honor-family` module already had a fully working export — this PR brings the other two entity-manager views to parity using the exact same pattern.

## How?

- **Department**: created a `server/action.server.ts` that did not previously exist. The action parses filter params from the URL (same `paramsSchema` as the loader), queries the database without pagination to fetch all active department members, calls the shared `buildMembersWithAttendances` helper to enrich attendance data, then `createMembersExcelFile` to produce the file.
- **Tribe**: same logic added to the existing `action.server.ts`. The export query (`getExportTribeMembers`) is added to `utils.server.ts`, reusing the private `getDateFilterOptions` already present in that file.
- In both cases, `currentUser.tribeId` / `honorFamilyId` / `departmentId` are explicitly set before calling `fetchAttendanceData` so the helper selects the correct attendance report type — same pattern used in the detail pages and the honor-family module.
- Excel file names follow the existing convention: `Membres du département <name>` / `Membres de la tribu <name>`.
- On the client side, the shared `useDownloadFile` hook watches the `downloadFetcher` and creates a temporary `<a>` element to trigger the download as soon as the `fileLink` is returned.

## Testing?

- Unit tests added/updated: no
- Integration / end-to-end tests: no
- Manual steps to verify locally:
  1. Log in as a department manager and navigate to `/department`
  2. Click the "Export" button in the toolbar
  3. Verify the `.xlsx` file downloads with the expected columns: Name, Phone, Email, previous month state, per-Sunday attendance, current month state
  4. Repeat steps 1–3 as a tribe manager on `/tribe`
  5. Test with active filters (status, date range, search query) to confirm the export respects the current filter state
- `pnpm typecheck`: ✅ no errors

## Anything Else?

- The `/honor-family` module already had this feature fully implemented — no functional change was made to it (only an auto-formatter whitespace diff appears in the diff).
- Follow-up: consider extracting the export action logic into a shared helper to reduce duplication across the three entity-manager modules.

## Checklist

- [ ] I added/updated tests (unit/integration)
- [ ] I updated documentation where necessary
- [ ] I ran the full test suite locally and it passes
- [ ] I verified this change in a staging environment (if applicable)
- [ ] This change requires a migration and I updated migration docs (if applicable)
